### PR TITLE
Test vcfParserImpl.java

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ dependencies {
   testImplementation 'junit:junit:4.12'
   testImplementation 'org.junit.jupiter:junit-jupiter:5.4.2'
   testImplementation 'org.mockito:mockito-core:3.3.3'
+  testImplementation 'com.google.guiceberry:guiceberry:3.3.1'
 }
 
 task vcfToBq(type:JavaExec) {

--- a/src/test/java/com/google/gcp_variant_transforms/TestEnv.java
+++ b/src/test/java/com/google/gcp_variant_transforms/TestEnv.java
@@ -1,0 +1,18 @@
+// Copyright 2020 Google LLC
+
+package com.google.gcp_variant_transforms;
+
+import com.google.gcp_variant_transforms.library.VcfParser;
+import com.google.gcp_variant_transforms.library.VcfParserImpl;
+import com.google.guiceberry.GuiceBerryModule;
+import com.google.inject.AbstractModule;
+
+public class TestEnv extends AbstractModule {
+
+  @Override
+  protected void configure() {
+    install(new GuiceBerryModule());
+
+    bind(VcfParser.class).to(VcfParserImpl.class);
+  }
+}

--- a/src/test/java/com/google/gcp_variant_transforms/library/VcfParserImplTest.java
+++ b/src/test/java/com/google/gcp_variant_transforms/library/VcfParserImplTest.java
@@ -13,13 +13,10 @@ import htsjdk.tribble.TribbleException;
 import htsjdk.variant.vcf.VCFCodec;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
 
 /**
  * Units tests for VcfParserImpl.java
  */
-@RunWith(MockitoJUnitRunner.class)
 public class VcfParserImplTest {
   private static final String FILE_FORMAT = "##fileformat=VCFv4.3";
   private static final String FILE_DATE = "##fileDate=20090805";

--- a/src/test/java/com/google/gcp_variant_transforms/library/VcfParserImplTest.java
+++ b/src/test/java/com/google/gcp_variant_transforms/library/VcfParserImplTest.java
@@ -43,6 +43,7 @@ public class VcfParserImplTest {
   @Test
   public void testGenerateCodecFromHeaderLines_withOutVcfVersion_thenThrowException() {
     ImmutableList.Builder<String> headerLinesBuilder = new ImmutableList.Builder<>();
+    headerLinesBuilder.add("##fileDate=20090805");
     headerLinesBuilder.add("#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tNA00001\tNA00002\tNA00003");
 
     // without specifying VCF version will throw TribbleException.InvalidHeader exception
@@ -60,9 +61,21 @@ public class VcfParserImplTest {
 
     // without VCF header line will throw TribbleException.InvalidHeader exception
     Exception invalidHeaderException = assertThrows(TribbleException.class, () ->
-            vcfParserImpl.generateCodecFromHeaderLines(headerLinesBuilder.build()));
+        vcfParserImpl.generateCodecFromHeaderLines(headerLinesBuilder.build()));
 
     assertThat(invalidHeaderException).hasMessageThat().contains("We never saw the required CHROM header line");
   }
 
+  @Test
+  public void testGenerateCodecFromHeaderLines_wrongHeaderFormat_thenThrowException() {
+    ImmutableList.Builder<String> headerLinesBuilder = new ImmutableList.Builder<>();
+    headerLinesBuilder.add("##fileformat=VCFv4.3");
+    headerLinesBuilder.add("#CHROM  POS  ID  REF  ALT  QUAL  FILTER  INFO  FORMAT  NA00001  NA00002  NA00003");
+
+    // Invalid VCF header line format will throw TribbleException.InvalidHeader exception
+    Exception invalidHeaderException = assertThrows(TribbleException.class, () ->
+            vcfParserImpl.generateCodecFromHeaderLines(headerLinesBuilder.build()));
+
+    assertThat(invalidHeaderException).hasMessageThat().contains("there are not enough columns present in the header line");
+  }
 }

--- a/src/test/java/com/google/gcp_variant_transforms/library/VcfParserImplTest.java
+++ b/src/test/java/com/google/gcp_variant_transforms/library/VcfParserImplTest.java
@@ -1,0 +1,69 @@
+// Copyright 2020 Google LLC
+
+package com.google.gcp_variant_transforms.library;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import com.google.common.collect.ImmutableList;
+import htsjdk.tribble.TribbleException;
+import htsjdk.variant.vcf.VCFCodec;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+/**
+ * Units tests for VcfParserImpl.java
+ */
+public class VcfParserImplTest {
+
+  @InjectMocks
+  private VcfParserImpl vcfParserImpl = new VcfParserImpl();
+
+//  @Mock
+//  private
+
+  private ImmutableList<String> headerLines;
+
+  @Before
+  public void buildHeaderLines() {
+    ImmutableList.Builder<String> headerLinesBuilder = new ImmutableList.Builder<>();
+    headerLinesBuilder.add("##fileformat=VCFv4.3");
+    headerLinesBuilder.add("#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tNA00001\tNA00002\tNA00003");
+    headerLines = headerLinesBuilder.build();
+  }
+
+  @Test
+  public void testGenerateCodecFromHeaderLines_whenCompareVCFCode_thenTrue() {
+    VCFCodec vcfCodec = vcfParserImpl.generateCodecFromHeaderLines(headerLines);
+    assertThat(vcfCodec instanceof VCFCodec).isTrue();
+  }
+
+  @Test
+  public void testGenerateCodecFromHeaderLines_withOutVCFVersion_thenThrowException() {
+    ImmutableList.Builder<String> headerLinesBuilder = new ImmutableList.Builder<>();
+    headerLinesBuilder.add("#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tNA00001\tNA00002\tNA00003");
+
+    // without specifying VCF version will throw TribbleException.InvalidHeader exception
+    Exception invalidHeaderException = assertThrows(TribbleException.class, () ->
+        vcfParserImpl.generateCodecFromHeaderLines(headerLinesBuilder.build()));
+
+    assertThat(invalidHeaderException).hasMessageThat().contains("We never saw a header line specifying VCF version");
+  }
+
+  @Test
+  public void testGenerateCodecFromHeaderLines_withOutHeaderLine_thenThrowException() {
+    ImmutableList.Builder<String> headerLinesBuilder = new ImmutableList.Builder<>();
+    headerLinesBuilder.add("##fileformat=VCFv4.3");
+    headerLinesBuilder.add("##fileDate=20090805");
+
+    // without VCF header line will throw TribbleException.InvalidHeader exception
+    Exception invalidHeaderException = assertThrows(TribbleException.class, () ->
+            vcfParserImpl.generateCodecFromHeaderLines(headerLinesBuilder.build()));
+
+    assertThat(invalidHeaderException).hasMessageThat().contains("We never saw the required CHROM header line");
+  }
+
+}

--- a/src/test/java/com/google/gcp_variant_transforms/library/VcfParserImplTest.java
+++ b/src/test/java/com/google/gcp_variant_transforms/library/VcfParserImplTest.java
@@ -22,7 +22,7 @@ public class VcfParserImplTest {
   private static final String FILE_DATE = "##fileDate=20090805";
   private static final String VALID_HEADER = "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO" +
           "\tFORMAT\tNA00001\tNA00002\tNA00003";
-  private static final String INVALID_HEADER = "#CHROM  POS  ID  REF  ALT  QUAL  FILTER  INFO  " +
+  private static final String INVALID_HEADER = "#CHROM POS  ID  REF  ALT  QUAL  FILTER  INFO  " +
           "FORMAT NA00001 NA00002  NA00003";
 
   @Rule

--- a/src/test/java/com/google/gcp_variant_transforms/library/VcfParserImplTest.java
+++ b/src/test/java/com/google/gcp_variant_transforms/library/VcfParserImplTest.java
@@ -31,53 +31,40 @@ public class VcfParserImplTest {
   @Inject
   public VcfParser vcfParser;
 
-  ImmutableList.Builder<String> headerLinesBuilder = new ImmutableList.Builder<>();
-
   @Test
   public void testGenerateCodecFromHeaderLines_whenCheckFunctionCall_thenTrue() {
-    headerLinesBuilder.add(FILE_FORMAT);
-    headerLinesBuilder.add(VALID_HEADER);
-    VCFCodec vcfCodec = vcfParser.generateCodecFromHeaderLines(headerLinesBuilder.build());
+    VCFCodec vcfCodec = vcfParser.generateCodecFromHeaderLines(ImmutableList.of(FILE_FORMAT, VALID_HEADER));
 
     assertThat(vcfCodec).isNotNull();
   }
 
   @Test
   public void testGenerateCodecFromHeaderLines_withoutVcfVersion_thenThrowException() {
-    headerLinesBuilder.add(FILE_DATE);
-    headerLinesBuilder.add(VALID_HEADER);
-
     // without specifying VCF version will throw TribbleException.InvalidHeader exception
     Exception invalidHeaderException = assertThrows(TribbleException.class, () ->
-              vcfParser.generateCodecFromHeaderLines(headerLinesBuilder.build()));
+          vcfParser.generateCodecFromHeaderLines(ImmutableList.of(FILE_DATE, VALID_HEADER)));
 
     assertThat(invalidHeaderException).hasMessageThat()
-               .contains("We never saw a header line specifying VCF version");
+          .contains("We never saw a header line specifying VCF version");
   }
 
   @Test
   public void testGenerateCodecFromHeaderLines_withoutHeaderLine_thenThrowException() {
-    headerLinesBuilder.add(FILE_FORMAT);
-    headerLinesBuilder.add(FILE_DATE);
-
     // without VCF header line will throw TribbleException.InvalidHeader exception
     Exception invalidHeaderException = assertThrows(TribbleException.class, () ->
-              vcfParser.generateCodecFromHeaderLines(headerLinesBuilder.build()));
+          vcfParser.generateCodecFromHeaderLines(ImmutableList.of(FILE_FORMAT, FILE_DATE)));
 
     assertThat(invalidHeaderException).hasMessageThat()
-               .contains("We never saw the required CHROM header line");
+          .contains("We never saw the required CHROM header line");
   }
 
   @Test
   public void testGenerateCodecFromHeaderLines_wrongHeaderFormat_thenThrowException() {
-    headerLinesBuilder.add(FILE_FORMAT);
-    headerLinesBuilder.add(INVALID_HEADER);
-
     // Invalid VCF header line format will throw TribbleException.InvalidHeader exception
     Exception invalidHeaderException = assertThrows(TribbleException.class, () ->
-              vcfParser.generateCodecFromHeaderLines(headerLinesBuilder.build()));
+          vcfParser.generateCodecFromHeaderLines(ImmutableList.of(FILE_FORMAT, INVALID_HEADER)));
 
     assertThat(invalidHeaderException).hasMessageThat()
-               .contains("there are not enough columns present in the header line");
+          .contains("there are not enough columns present in the header line");
   }
 }

--- a/src/test/java/com/google/gcp_variant_transforms/library/VcfParserImplTest.java
+++ b/src/test/java/com/google/gcp_variant_transforms/library/VcfParserImplTest.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.google.common.collect.ImmutableList;
 import htsjdk.tribble.TribbleException;
 import htsjdk.variant.vcf.VCFCodec;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -19,63 +18,63 @@ import org.mockito.junit.MockitoJUnitRunner;
  */
 @RunWith(MockitoJUnitRunner.class)
 public class VcfParserImplTest {
+  private static final String FILE_FORMAT = "##fileformat=VCFv4.3";
+  private static final String FILE_DATE = "##fileDate=20090805";
+  private static final String VALID_HEADER = "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO" +
+          "\tFORMAT\tNA00001\tNA00002\tNA00003";
+  private static final String INVALID_HEADER = "#CHROM  POS  ID  REF  ALT  QUAL  FILTER  INFO  " +
+          "FORMAT  NA00001 NA00002  NA00003";
 
   @InjectMocks
   VcfParserImpl vcfParserImpl;
 
-  ImmutableList<String> headerLines;
-
-  @Before
-  public void buildHeaderLines() {
-    ImmutableList.Builder<String> headerLinesBuilder = new ImmutableList.Builder<>();
-    headerLinesBuilder.add("##fileformat=VCFv4.3");
-    headerLinesBuilder.add("#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tNA00001\tNA00002\tNA00003");
-    headerLines = headerLinesBuilder.build();
-  }
+  ImmutableList.Builder<String> headerLinesBuilder = new ImmutableList.Builder<>();
 
   @Test
   public void testGenerateCodecFromHeaderLines_whenCheckFunctionCall_thenTrue() {
-    VCFCodec vcfCodec = vcfParserImpl.generateCodecFromHeaderLines(headerLines);
+    headerLinesBuilder.add(FILE_FORMAT);
+    headerLinesBuilder.add(VALID_HEADER);
+    VCFCodec vcfCodec = vcfParserImpl.generateCodecFromHeaderLines(headerLinesBuilder.build());
 
     assertThat(vcfCodec).isNotNull();
   }
 
   @Test
-  public void testGenerateCodecFromHeaderLines_withOutVcfVersion_thenThrowException() {
-    ImmutableList.Builder<String> headerLinesBuilder = new ImmutableList.Builder<>();
-    headerLinesBuilder.add("##fileDate=20090805");
-    headerLinesBuilder.add("#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tNA00001\tNA00002\tNA00003");
+  public void testGenerateCodecFromHeaderLines_withoutVcfVersion_thenThrowException() {
+    headerLinesBuilder.add(FILE_DATE);
+    headerLinesBuilder.add(VALID_HEADER);
 
     // without specifying VCF version will throw TribbleException.InvalidHeader exception
     Exception invalidHeaderException = assertThrows(TribbleException.class, () ->
         vcfParserImpl.generateCodecFromHeaderLines(headerLinesBuilder.build()));
 
-    assertThat(invalidHeaderException).hasMessageThat().contains("We never saw a header line specifying VCF version");
+    assertThat(invalidHeaderException).hasMessageThat()
+               .contains("We never saw a header line specifying VCF version");
   }
 
   @Test
-  public void testGenerateCodecFromHeaderLines_withOutHeaderLine_thenThrowException() {
-    ImmutableList.Builder<String> headerLinesBuilder = new ImmutableList.Builder<>();
-    headerLinesBuilder.add("##fileformat=VCFv4.3");
-    headerLinesBuilder.add("##fileDate=20090805");
+  public void testGenerateCodecFromHeaderLines_withoutHeaderLine_thenThrowException() {
+    headerLinesBuilder.add(FILE_FORMAT);
+    headerLinesBuilder.add(FILE_DATE);
 
     // without VCF header line will throw TribbleException.InvalidHeader exception
     Exception invalidHeaderException = assertThrows(TribbleException.class, () ->
         vcfParserImpl.generateCodecFromHeaderLines(headerLinesBuilder.build()));
 
-    assertThat(invalidHeaderException).hasMessageThat().contains("We never saw the required CHROM header line");
+    assertThat(invalidHeaderException).hasMessageThat()
+               .contains("We never saw the required CHROM header line");
   }
 
   @Test
   public void testGenerateCodecFromHeaderLines_wrongHeaderFormat_thenThrowException() {
-    ImmutableList.Builder<String> headerLinesBuilder = new ImmutableList.Builder<>();
-    headerLinesBuilder.add("##fileformat=VCFv4.3");
-    headerLinesBuilder.add("#CHROM  POS  ID  REF  ALT  QUAL  FILTER  INFO  FORMAT  NA00001  NA00002  NA00003");
+    headerLinesBuilder.add(FILE_FORMAT);
+    headerLinesBuilder.add(INVALID_HEADER);
 
     // Invalid VCF header line format will throw TribbleException.InvalidHeader exception
     Exception invalidHeaderException = assertThrows(TribbleException.class, () ->
             vcfParserImpl.generateCodecFromHeaderLines(headerLinesBuilder.build()));
 
-    assertThat(invalidHeaderException).hasMessageThat().contains("there are not enough columns present in the header line");
+    assertThat(invalidHeaderException).hasMessageThat()
+               .contains("there are not enough columns present in the header line");
   }
 }

--- a/src/test/java/com/google/gcp_variant_transforms/library/VcfParserImplTest.java
+++ b/src/test/java/com/google/gcp_variant_transforms/library/VcfParserImplTest.java
@@ -23,7 +23,7 @@ public class VcfParserImplTest {
   private static final String VALID_HEADER = "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO" +
           "\tFORMAT\tNA00001\tNA00002\tNA00003";
   private static final String INVALID_HEADER = "#CHROM  POS  ID  REF  ALT  QUAL  FILTER  INFO  " +
-          "FORMAT  NA00001 NA00002  NA00003";
+          "FORMAT NA00001 NA00002  NA00003";
 
   @Rule
   public final GuiceBerryRule guiceBerry = new GuiceBerryRule(TestEnv.class);

--- a/src/test/java/com/google/gcp_variant_transforms/library/VcfParserImplTest.java
+++ b/src/test/java/com/google/gcp_variant_transforms/library/VcfParserImplTest.java
@@ -6,11 +6,14 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.ImmutableList;
+import com.google.gcp_variant_transforms.TestEnv;
+import com.google.guiceberry.junit4.GuiceBerryRule;
+import com.google.inject.Inject;
 import htsjdk.tribble.TribbleException;
 import htsjdk.variant.vcf.VCFCodec;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
 import org.mockito.junit.MockitoJUnitRunner;
 
 /**
@@ -25,8 +28,11 @@ public class VcfParserImplTest {
   private static final String INVALID_HEADER = "#CHROM  POS  ID  REF  ALT  QUAL  FILTER  INFO  " +
           "FORMAT  NA00001 NA00002  NA00003";
 
-  @InjectMocks
-  VcfParserImpl vcfParserImpl;
+  @Rule
+  public final GuiceBerryRule guiceBerry = new GuiceBerryRule(TestEnv.class);
+
+  @Inject
+  public VcfParser vcfParser;
 
   ImmutableList.Builder<String> headerLinesBuilder = new ImmutableList.Builder<>();
 
@@ -34,7 +40,7 @@ public class VcfParserImplTest {
   public void testGenerateCodecFromHeaderLines_whenCheckFunctionCall_thenTrue() {
     headerLinesBuilder.add(FILE_FORMAT);
     headerLinesBuilder.add(VALID_HEADER);
-    VCFCodec vcfCodec = vcfParserImpl.generateCodecFromHeaderLines(headerLinesBuilder.build());
+    VCFCodec vcfCodec = vcfParser.generateCodecFromHeaderLines(headerLinesBuilder.build());
 
     assertThat(vcfCodec).isNotNull();
   }
@@ -46,7 +52,7 @@ public class VcfParserImplTest {
 
     // without specifying VCF version will throw TribbleException.InvalidHeader exception
     Exception invalidHeaderException = assertThrows(TribbleException.class, () ->
-        vcfParserImpl.generateCodecFromHeaderLines(headerLinesBuilder.build()));
+              vcfParser.generateCodecFromHeaderLines(headerLinesBuilder.build()));
 
     assertThat(invalidHeaderException).hasMessageThat()
                .contains("We never saw a header line specifying VCF version");
@@ -59,7 +65,7 @@ public class VcfParserImplTest {
 
     // without VCF header line will throw TribbleException.InvalidHeader exception
     Exception invalidHeaderException = assertThrows(TribbleException.class, () ->
-        vcfParserImpl.generateCodecFromHeaderLines(headerLinesBuilder.build()));
+              vcfParser.generateCodecFromHeaderLines(headerLinesBuilder.build()));
 
     assertThat(invalidHeaderException).hasMessageThat()
                .contains("We never saw the required CHROM header line");
@@ -72,7 +78,7 @@ public class VcfParserImplTest {
 
     // Invalid VCF header line format will throw TribbleException.InvalidHeader exception
     Exception invalidHeaderException = assertThrows(TribbleException.class, () ->
-            vcfParserImpl.generateCodecFromHeaderLines(headerLinesBuilder.build()));
+              vcfParser.generateCodecFromHeaderLines(headerLinesBuilder.build()));
 
     assertThat(invalidHeaderException).hasMessageThat()
                .contains("there are not enough columns present in the header line");

--- a/src/test/java/com/google/gcp_variant_transforms/library/VcfParserImplTest.java
+++ b/src/test/java/com/google/gcp_variant_transforms/library/VcfParserImplTest.java
@@ -4,28 +4,26 @@ package com.google.gcp_variant_transforms.library;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
 
 import com.google.common.collect.ImmutableList;
 import htsjdk.tribble.TribbleException;
 import htsjdk.variant.vcf.VCFCodec;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 /**
  * Units tests for VcfParserImpl.java
  */
+@RunWith(MockitoJUnitRunner.class)
 public class VcfParserImplTest {
 
   @InjectMocks
-  private VcfParserImpl vcfParserImpl = new VcfParserImpl();
+  VcfParserImpl vcfParserImpl;
 
-//  @Mock
-//  private
-
-  private ImmutableList<String> headerLines;
+  ImmutableList<String> headerLines;
 
   @Before
   public void buildHeaderLines() {
@@ -36,13 +34,14 @@ public class VcfParserImplTest {
   }
 
   @Test
-  public void testGenerateCodecFromHeaderLines_whenCompareVCFCode_thenTrue() {
+  public void testGenerateCodecFromHeaderLines_whenCheckFunctionCall_thenTrue() {
     VCFCodec vcfCodec = vcfParserImpl.generateCodecFromHeaderLines(headerLines);
-    assertThat(vcfCodec instanceof VCFCodec).isTrue();
+
+    assertThat(vcfCodec).isNotNull();
   }
 
   @Test
-  public void testGenerateCodecFromHeaderLines_withOutVCFVersion_thenThrowException() {
+  public void testGenerateCodecFromHeaderLines_withOutVcfVersion_thenThrowException() {
     ImmutableList.Builder<String> headerLinesBuilder = new ImmutableList.Builder<>();
     headerLinesBuilder.add("#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tNA00001\tNA00002\tNA00003");
 


### PR DESCRIPTION
Variant.java tested
I have used

Google truth to assert the expected VCFCodec object has beed created and Junit assertThrows to handle invalid header exception;
Mockito InjectMock to mock the VcfParserImpl instance to test the VCFCodec generating function.

Usage
```
./gradlew test
```