### PR TITLE
VcfToBqContext.java Unit Tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ gradlew.bat
 # Ignore IntelliJ project files
 .idea
 gcp-variant-transforms-java.iml
+
+#Ignore VSCode files
+.vscode/

--- a/src/main/java/com/google/gcp_variant_transforms/options/AbstractContext.java
+++ b/src/main/java/com/google/gcp_variant_transforms/options/AbstractContext.java
@@ -10,7 +10,6 @@ import java.io.IOException;
 public abstract class AbstractContext {
 
   public AbstractContext(PipelineOptions options) {
-    configureFilesystems(options);
   }
 
   /**
@@ -20,8 +19,4 @@ public abstract class AbstractContext {
    */
   protected abstract void validateFlags() throws IOException;
 
-  /** configures filesystem to the corresponding options, regardless of task. */
-  private void configureFilesystems(PipelineOptions options) {
-    FileSystems.setDefaultPipelineOptions(options);
-  }
 }

--- a/src/main/java/com/google/gcp_variant_transforms/task/VcfToBqTask.java
+++ b/src/main/java/com/google/gcp_variant_transforms/task/VcfToBqTask.java
@@ -2,12 +2,15 @@
 
 package com.google.gcp_variant_transforms.task;
 
+import org.apache.beam.sdk.io.FileSystems;
+import org.apache.beam.sdk.options.PipelineOptions;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.google.gcp_variant_transforms.beam.PipelineRunner;
 import com.google.gcp_variant_transforms.library.HeaderReader;
 import com.google.gcp_variant_transforms.options.VcfToBqContext;
+import com.google.gcp_variant_transforms.options.VcfToBqOptions;
 
 import java.io.IOException;
 
@@ -19,21 +22,30 @@ public class VcfToBqTask implements Task {
   private final HeaderReader headerReader;
   private final PipelineRunner pipelineRunner;
   private final VcfToBqContext context;
+  private final PipelineOptions options;
 
   @Inject
   public VcfToBqTask(
         PipelineRunner pipelineRunner,
         HeaderReader headerReader,
-        VcfToBqContext context) throws IOException {
+        VcfToBqContext context,
+        VcfToBqOptions options) throws IOException {
     this.pipelineRunner = pipelineRunner;
     this.headerReader = headerReader;
     this.context = context;
+    this.options = (PipelineOptions) options;
   }
 
   @Override
   public void run() throws IOException {
+    setPipelineOptions(this.options);
     context.setHeaderLines(headerReader.getHeaderLines());
     pipelineRunner.runPipeline();
+  }
+
+  /** configures filesystem to the corresponding options, regardless of task. */
+  protected void setPipelineOptions(PipelineOptions options) {
+    FileSystems.setDefaultPipelineOptions(options);
   }
 
   public static void main(String[] args) throws IOException {

--- a/src/test/java/com/google/gcp_variant_transforms/options/VcfToBqContextTest.java
+++ b/src/test/java/com/google/gcp_variant_transforms/options/VcfToBqContextTest.java
@@ -18,7 +18,8 @@ public class VcfToBqContextTest {
   
   private static final String INPUT_FILE = "sampleInputFile.txt";
   private static final String OUTPUT = "sampleOutput";
-  private final VcfToBqOptions MOCKED_VCFTOBQ_OPTIONS = create_mockedVcfToBqOptions(INPUT_FILE, OUTPUT);
+  private final VcfToBqOptions MOCKED_VCF_TO_BQ_OPTIONS = create_mockedVcfToBqOptions(
+      INPUT_FILE, OUTPUT);
  
   public VcfToBqOptions create_mockedVcfToBqOptions(String inputFile, String output) {
     VcfToBqOptions mockedVcfToBqOptions = mock(VcfToBqOptions.class);
@@ -37,7 +38,7 @@ public class VcfToBqContextTest {
  
   @Test
   public void testVcfContextConstructor_whenCompareFields_thenMatches() throws IOException {
-    VcfToBqContext vcfToBqContext = new VcfToBqContext(MOCKED_VCFTOBQ_OPTIONS);
+    VcfToBqContext vcfToBqContext = new VcfToBqContext(MOCKED_VCF_TO_BQ_OPTIONS);
  
     assertThat(vcfToBqContext.getInputFile()).matches(INPUT_FILE);
     assertThat(vcfToBqContext.getOutput()).matches(OUTPUT);
@@ -54,7 +55,7 @@ public class VcfToBqContextTest {
  
   @Test
   public void testVcfContext_whenGetInputFile_thenMatches() throws IOException {
-    VcfToBqContext vcfToBqContext = new VcfToBqContext(MOCKED_VCFTOBQ_OPTIONS);
+    VcfToBqContext vcfToBqContext = new VcfToBqContext(MOCKED_VCF_TO_BQ_OPTIONS);
  
     assertThat(vcfToBqContext.getInputFile()).matches(INPUT_FILE);
   }
@@ -71,7 +72,7 @@ public class VcfToBqContextTest {
  
   @Test
   public void testVcfContext_whenGetOutput_thenMatches() throws IOException {
-    VcfToBqContext vcfToBqContext = new VcfToBqContext(MOCKED_VCFTOBQ_OPTIONS);   
+    VcfToBqContext vcfToBqContext = new VcfToBqContext(MOCKED_VCF_TO_BQ_OPTIONS);   
  
     assertThat(vcfToBqContext.getOutput()).matches(OUTPUT);
   }
@@ -88,7 +89,7 @@ public class VcfToBqContextTest {
  
  @Test
  public void testVcfContext_whenSetHeaderLines_thenMatches() throws IOException {
-    VcfToBqContext vcfToBqContext = new VcfToBqContext(MOCKED_VCFTOBQ_OPTIONS);   
+    VcfToBqContext vcfToBqContext = new VcfToBqContext(MOCKED_VCF_TO_BQ_OPTIONS);   
     ImmutableList<String> headerLines = createHeaderLines();
     vcfToBqContext.setHeaderLines(headerLines);
  
@@ -97,7 +98,7 @@ public class VcfToBqContextTest {
  
   @Test
   public void testVcfContext_whenSetHeaderLines_thenNull() throws IOException {
-    VcfToBqContext vcfToBqContext = new VcfToBqContext(MOCKED_VCFTOBQ_OPTIONS);   
+    VcfToBqContext vcfToBqContext = new VcfToBqContext(MOCKED_VCF_TO_BQ_OPTIONS);   
     vcfToBqContext.setHeaderLines(null);
  
     assertThat(vcfToBqContext.getHeaderLines()).isNull();
@@ -105,7 +106,7 @@ public class VcfToBqContextTest {
  
   @Test
   public void testVcfContext_whenGetHeaderLines_thenNull() throws IOException {
-    VcfToBqContext vcfToBqContext = new VcfToBqContext(MOCKED_VCFTOBQ_OPTIONS);   
+    VcfToBqContext vcfToBqContext = new VcfToBqContext(MOCKED_VCF_TO_BQ_OPTIONS);   
  
     assertThat(vcfToBqContext.getHeaderLines()).isNull();
   }

--- a/src/test/java/com/google/gcp_variant_transforms/options/VcfToBqContextTest.java
+++ b/src/test/java/com/google/gcp_variant_transforms/options/VcfToBqContextTest.java
@@ -1,0 +1,130 @@
+// Copyright 2020 Google LLC
+ 
+package com.google.gcp_variant_transforms.options;
+ 
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+ 
+import com.google.common.collect.ImmutableList;
+import com.google.gcp_variant_transforms.options.VcfToBqContext;
+import java.io.IOException;
+import org.junit.Test;
+ 
+/**
+* Units tests for VcfToBqContext.java
+*/
+public class VcfToBqContextTest {
+ 
+ public VcfToBqOptions create_mockedVcfToBqOptions(String inputFile, String output) {
+   VcfToBqOptions mockedVcfToBqOptions = mock(VcfToBqOptions.class);
+   when(mockedVcfToBqOptions.getInputFile()).thenReturn(inputFile);
+   when(mockedVcfToBqOptions.getOutput()).thenReturn(output);
+   return mockedVcfToBqOptions;
+ }
+ 
+ public ImmutableList<String> createHeaderLines() {
+   ImmutableList.Builder<String> headerLinesBuilder = new ImmutableList.Builder<String>();
+   for (int i = 0; i < 10; i++) {
+     headerLinesBuilder.add("##sampleHeaderLine=" + i);
+   }
+   return headerLinesBuilder.build();
+ }
+ 
+ @Test
+ public void testVcfContextConstructor_whenCompareFields_thenMatches() throws IOException {
+   String inputFile = "sampleInputFile.txt";
+   String output = "sampleOutputFile.txt";
+   VcfToBqOptions mockedVcfToBqOptions = create_mockedVcfToBqOptions(inputFile, output);
+   VcfToBqContext vcfToBqContext = new VcfToBqContext(mockedVcfToBqOptions);
+ 
+   assertThat(vcfToBqContext.getInputFile()).matches(inputFile);
+   assertThat(vcfToBqContext.getOutput()).matches(output);
+   assertThat(vcfToBqContext.getHeaderLines()).isNull();
+ }
+ 
+ @Test
+ public void testVcfContext_whenValidateFlags_thenException(){
+   VcfToBqOptions mockedVcfToBqOptions = create_mockedVcfToBqOptions(null, null);
+   
+   assertThrows(IOException.class, () ->
+       new VcfToBqContext(mockedVcfToBqOptions)); 
+ }
+ 
+ @Test
+ public void testVcfContext_whenGetInputFile_thenMatches() throws IOException {
+   String inputFile = "sampleInputFile.txt";
+   VcfToBqOptions mockedVcfToBqOptions = create_mockedVcfToBqOptions(
+       inputFile,
+       "sampleOutputFile.txt");
+   VcfToBqContext vcfToBqContext = new VcfToBqContext(mockedVcfToBqOptions);
+ 
+   assertThat(vcfToBqContext.getInputFile()).matches(inputFile);
+ }
+ 
+ @Test
+ public void testVcfContext_whenInputFileNull_thenNull() throws IOException {
+   VcfToBqOptions mockedVcfToBqOptions = create_mockedVcfToBqOptions(
+       null,
+       "sampleOutputFile.txt");
+   VcfToBqContext vcfToBqContext = new VcfToBqContext(mockedVcfToBqOptions);
+  
+   assertThat(vcfToBqContext.getInputFile()).isNull();
+ 
+ }
+ 
+ @Test
+ public void testVcfContext_whenGetOutput_thenMatches() throws IOException {
+   String output = "sampleOutputFile.txt";
+   VcfToBqOptions mockedVcfToBqOptions = create_mockedVcfToBqOptions(
+       "sampleInputFile.txt",
+       output);
+   VcfToBqContext vcfToBqContext = new VcfToBqContext(mockedVcfToBqOptions);   
+ 
+   assertThat(vcfToBqContext.getOutput()).matches(output);
+ }
+ 
+ @Test
+ public void testVcfContext_whenNullOutput_thenException() throws IOException {
+   VcfToBqOptions mockedVcfToBqOptions = create_mockedVcfToBqOptions(
+       "sampleInputFile.txt",
+       null);
+ 
+   assertThrows(IOException.class, () ->
+       new VcfToBqContext(mockedVcfToBqOptions));   
+ }
+ 
+ @Test
+ public void testVcfContext_whenSetHeaderLines_thenMatches() throws IOException {
+   VcfToBqOptions mockedVcfToBqOptions = create_mockedVcfToBqOptions(
+       "sampleInputFile.txt",
+       "sampleOutputFile.txt");
+   VcfToBqContext vcfToBqContext = new VcfToBqContext(mockedVcfToBqOptions);   
+   ImmutableList<String> headerLines = createHeaderLines();
+   vcfToBqContext.setHeaderLines(headerLines);
+ 
+   assertThat(vcfToBqContext.getHeaderLines()).containsExactlyElementsIn(headerLines);
+ }
+ 
+ @Test
+ public void testVcfContext_whenSetHeaderLines_thenNull() throws IOException {
+   VcfToBqOptions mockedVcfToBqOptions = create_mockedVcfToBqOptions(
+       "sampleInputFile.txt",
+       "sampleOutputFile.txt");
+   VcfToBqContext vcfToBqContext = new VcfToBqContext(mockedVcfToBqOptions);   
+   vcfToBqContext.setHeaderLines(null);
+ 
+   assertThat(vcfToBqContext.getHeaderLines()).isNull();
+ }
+ 
+ @Test
+ public void testVcfContext_whenGetHeaderLines_thenNull() throws IOException {
+   VcfToBqOptions mockedVcfToBqOptions = create_mockedVcfToBqOptions(
+       "sampleInputFile.txt",
+       "sampleOutputFile.txt");
+   VcfToBqContext vcfToBqContext = new VcfToBqContext(mockedVcfToBqOptions);   
+ 
+   assertThat(vcfToBqContext.getHeaderLines()).isNull();
+ }
+}

--- a/src/test/java/com/google/gcp_variant_transforms/options/VcfToBqContextTest.java
+++ b/src/test/java/com/google/gcp_variant_transforms/options/VcfToBqContextTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
  
 import com.google.common.collect.ImmutableList;
-import com.google.gcp_variant_transforms.options.VcfToBqContext;
 import java.io.IOException;
 import org.junit.Test;
  
@@ -16,115 +15,113 @@ import org.junit.Test;
 * Units tests for VcfToBqContext.java
 */
 public class VcfToBqContextTest {
- 
- public VcfToBqOptions create_mockedVcfToBqOptions(String inputFile, String output) {
-   VcfToBqOptions mockedVcfToBqOptions = mock(VcfToBqOptions.class);
-   when(mockedVcfToBqOptions.getInputFile()).thenReturn(inputFile);
-   when(mockedVcfToBqOptions.getOutput()).thenReturn(output);
-   return mockedVcfToBqOptions;
- }
- 
- public ImmutableList<String> createHeaderLines() {
-   ImmutableList.Builder<String> headerLinesBuilder = new ImmutableList.Builder<String>();
-   for (int i = 0; i < 10; i++) {
-     headerLinesBuilder.add("##sampleHeaderLine=" + i);
-   }
-   return headerLinesBuilder.build();
- }
- 
- @Test
- public void testVcfContextConstructor_whenCompareFields_thenMatches() throws IOException {
-   String inputFile = "sampleInputFile.txt";
-   String output = "sampleOutputFile.txt";
-   VcfToBqOptions mockedVcfToBqOptions = create_mockedVcfToBqOptions(inputFile, output);
-   VcfToBqContext vcfToBqContext = new VcfToBqContext(mockedVcfToBqOptions);
- 
-   assertThat(vcfToBqContext.getInputFile()).matches(inputFile);
-   assertThat(vcfToBqContext.getOutput()).matches(output);
-   assertThat(vcfToBqContext.getHeaderLines()).isNull();
- }
- 
- @Test
- public void testVcfContext_whenValidateFlags_thenException(){
-   VcfToBqOptions mockedVcfToBqOptions = create_mockedVcfToBqOptions(null, null);
-   
-   assertThrows(IOException.class, () ->
-       new VcfToBqContext(mockedVcfToBqOptions)); 
- }
- 
- @Test
- public void testVcfContext_whenGetInputFile_thenMatches() throws IOException {
-   String inputFile = "sampleInputFile.txt";
-   VcfToBqOptions mockedVcfToBqOptions = create_mockedVcfToBqOptions(
-       inputFile,
-       "sampleOutputFile.txt");
-   VcfToBqContext vcfToBqContext = new VcfToBqContext(mockedVcfToBqOptions);
- 
-   assertThat(vcfToBqContext.getInputFile()).matches(inputFile);
- }
- 
- @Test
- public void testVcfContext_whenInputFileNull_thenNull() throws IOException {
-   VcfToBqOptions mockedVcfToBqOptions = create_mockedVcfToBqOptions(
-       null,
-       "sampleOutputFile.txt");
-   VcfToBqContext vcfToBqContext = new VcfToBqContext(mockedVcfToBqOptions);
   
-   assertThat(vcfToBqContext.getInputFile()).isNull();
+  private static final String INPUT_FILE = "sampleInputFile.txt";
+  private static final String OUTPUT = "sampleOutput";
  
+  public VcfToBqOptions create_mockedVcfToBqOptions(String inputFile, String output) {
+    VcfToBqOptions mockedVcfToBqOptions = mock(VcfToBqOptions.class);
+    when(mockedVcfToBqOptions.getInputFile()).thenReturn(inputFile);
+    when(mockedVcfToBqOptions.getOutput()).thenReturn(output);
+    return mockedVcfToBqOptions;
+  }
+ 
+  public ImmutableList<String> createHeaderLines() {
+    ImmutableList.Builder<String> headerLinesBuilder = new ImmutableList.Builder<String>();
+    for (int i = 0; i < 10; i++) {
+      headerLinesBuilder.add("##sampleHeaderLine=" + i);
+    }
+    return headerLinesBuilder.build();
+  }
+ 
+  @Test
+  public void testVcfContextConstructor_whenCompareFields_thenMatches() throws IOException {
+    VcfToBqOptions mockedVcfToBqOptions = create_mockedVcfToBqOptions(INPUT_FILE, OUTPUT);
+    VcfToBqContext vcfToBqContext = new VcfToBqContext(mockedVcfToBqOptions);
+ 
+    assertThat(vcfToBqContext.getInputFile()).matches(INPUT_FILE);
+    assertThat(vcfToBqContext.getOutput()).matches(OUTPUT);
+    assertThat(vcfToBqContext.getHeaderLines()).isNull();
  }
  
- @Test
- public void testVcfContext_whenGetOutput_thenMatches() throws IOException {
-   String output = "sampleOutputFile.txt";
-   VcfToBqOptions mockedVcfToBqOptions = create_mockedVcfToBqOptions(
-       "sampleInputFile.txt",
-       output);
-   VcfToBqContext vcfToBqContext = new VcfToBqContext(mockedVcfToBqOptions);   
+  @Test
+  public void testVcfContext_whenValidateFlags_thenException(){
+    VcfToBqOptions mockedVcfToBqOptions = create_mockedVcfToBqOptions(null, null);
+   
+    assertThrows(IOException.class, () ->
+        new VcfToBqContext(mockedVcfToBqOptions)); 
+  }
  
-   assertThat(vcfToBqContext.getOutput()).matches(output);
- }
+  @Test
+  public void testVcfContext_whenGetInputFile_thenMatches() throws IOException {
+    VcfToBqOptions mockedVcfToBqOptions = create_mockedVcfToBqOptions(
+        INPUT_FILE,
+        OUTPUT);
+    VcfToBqContext vcfToBqContext = new VcfToBqContext(mockedVcfToBqOptions);
  
- @Test
- public void testVcfContext_whenNullOutput_thenException() throws IOException {
-   VcfToBqOptions mockedVcfToBqOptions = create_mockedVcfToBqOptions(
-       "sampleInputFile.txt",
-       null);
+    assertThat(vcfToBqContext.getInputFile()).matches(INPUT_FILE);
+  }
  
-   assertThrows(IOException.class, () ->
-       new VcfToBqContext(mockedVcfToBqOptions));   
- }
+  @Test
+  public void testVcfContext_whenInputFileNull_thenNull() throws IOException {
+    VcfToBqOptions mockedVcfToBqOptions = create_mockedVcfToBqOptions(
+        null,
+        OUTPUT);
+    VcfToBqContext vcfToBqContext = new VcfToBqContext(mockedVcfToBqOptions);
+  
+    assertThat(vcfToBqContext.getInputFile()).isNull();
+  }
+ 
+  @Test
+  public void testVcfContext_whenGetOutput_thenMatches() throws IOException {
+    VcfToBqOptions mockedVcfToBqOptions = create_mockedVcfToBqOptions(
+        INPUT_FILE,
+        OUTPUT);
+    VcfToBqContext vcfToBqContext = new VcfToBqContext(mockedVcfToBqOptions);   
+ 
+    assertThat(vcfToBqContext.getOutput()).matches(OUTPUT);
+  }
+ 
+  @Test
+  public void testVcfContext_whenNullOutput_thenException() throws IOException {
+    VcfToBqOptions mockedVcfToBqOptions = create_mockedVcfToBqOptions(
+        INPUT_FILE,
+        null);
+ 
+    assertThrows(IOException.class, () ->
+        new VcfToBqContext(mockedVcfToBqOptions));   
+  }
  
  @Test
  public void testVcfContext_whenSetHeaderLines_thenMatches() throws IOException {
-   VcfToBqOptions mockedVcfToBqOptions = create_mockedVcfToBqOptions(
-       "sampleInputFile.txt",
-       "sampleOutputFile.txt");
-   VcfToBqContext vcfToBqContext = new VcfToBqContext(mockedVcfToBqOptions);   
-   ImmutableList<String> headerLines = createHeaderLines();
-   vcfToBqContext.setHeaderLines(headerLines);
+    VcfToBqOptions mockedVcfToBqOptions = create_mockedVcfToBqOptions(
+        INPUT_FILE,
+        OUTPUT);
+    VcfToBqContext vcfToBqContext = new VcfToBqContext(mockedVcfToBqOptions);   
+    ImmutableList<String> headerLines = createHeaderLines();
+    vcfToBqContext.setHeaderLines(headerLines);
  
-   assertThat(vcfToBqContext.getHeaderLines()).containsExactlyElementsIn(headerLines);
- }
+    assertThat(vcfToBqContext.getHeaderLines()).containsExactlyElementsIn(headerLines);
+  }
  
- @Test
- public void testVcfContext_whenSetHeaderLines_thenNull() throws IOException {
-   VcfToBqOptions mockedVcfToBqOptions = create_mockedVcfToBqOptions(
-       "sampleInputFile.txt",
-       "sampleOutputFile.txt");
-   VcfToBqContext vcfToBqContext = new VcfToBqContext(mockedVcfToBqOptions);   
-   vcfToBqContext.setHeaderLines(null);
+  @Test
+  public void testVcfContext_whenSetHeaderLines_thenNull() throws IOException {
+    VcfToBqOptions mockedVcfToBqOptions = create_mockedVcfToBqOptions(
+        INPUT_FILE,
+        OUTPUT);
+    VcfToBqContext vcfToBqContext = new VcfToBqContext(mockedVcfToBqOptions);   
+    vcfToBqContext.setHeaderLines(null);
  
-   assertThat(vcfToBqContext.getHeaderLines()).isNull();
- }
+    assertThat(vcfToBqContext.getHeaderLines()).isNull();
+  }
  
- @Test
- public void testVcfContext_whenGetHeaderLines_thenNull() throws IOException {
-   VcfToBqOptions mockedVcfToBqOptions = create_mockedVcfToBqOptions(
-       "sampleInputFile.txt",
-       "sampleOutputFile.txt");
-   VcfToBqContext vcfToBqContext = new VcfToBqContext(mockedVcfToBqOptions);   
+  @Test
+  public void testVcfContext_whenGetHeaderLines_thenNull() throws IOException {
+    VcfToBqOptions mockedVcfToBqOptions = create_mockedVcfToBqOptions(
+        INPUT_FILE,
+        OUTPUT);
+    VcfToBqContext vcfToBqContext = new VcfToBqContext(mockedVcfToBqOptions);   
  
-   assertThat(vcfToBqContext.getHeaderLines()).isNull();
- }
+    assertThat(vcfToBqContext.getHeaderLines()).isNull();
+  }
 }

--- a/src/test/java/com/google/gcp_variant_transforms/options/VcfToBqContextTest.java
+++ b/src/test/java/com/google/gcp_variant_transforms/options/VcfToBqContextTest.java
@@ -18,6 +18,7 @@ public class VcfToBqContextTest {
   
   private static final String INPUT_FILE = "sampleInputFile.txt";
   private static final String OUTPUT = "sampleOutput";
+  private final VcfToBqOptions MOCKED_VCFTOBQ_OPTIONS = create_mockedVcfToBqOptions(INPUT_FILE, OUTPUT);
  
   public VcfToBqOptions create_mockedVcfToBqOptions(String inputFile, String output) {
     VcfToBqOptions mockedVcfToBqOptions = mock(VcfToBqOptions.class);
@@ -36,8 +37,7 @@ public class VcfToBqContextTest {
  
   @Test
   public void testVcfContextConstructor_whenCompareFields_thenMatches() throws IOException {
-    VcfToBqOptions mockedVcfToBqOptions = create_mockedVcfToBqOptions(INPUT_FILE, OUTPUT);
-    VcfToBqContext vcfToBqContext = new VcfToBqContext(mockedVcfToBqOptions);
+    VcfToBqContext vcfToBqContext = new VcfToBqContext(MOCKED_VCFTOBQ_OPTIONS);
  
     assertThat(vcfToBqContext.getInputFile()).matches(INPUT_FILE);
     assertThat(vcfToBqContext.getOutput()).matches(OUTPUT);
@@ -54,10 +54,7 @@ public class VcfToBqContextTest {
  
   @Test
   public void testVcfContext_whenGetInputFile_thenMatches() throws IOException {
-    VcfToBqOptions mockedVcfToBqOptions = create_mockedVcfToBqOptions(
-        INPUT_FILE,
-        OUTPUT);
-    VcfToBqContext vcfToBqContext = new VcfToBqContext(mockedVcfToBqOptions);
+    VcfToBqContext vcfToBqContext = new VcfToBqContext(MOCKED_VCFTOBQ_OPTIONS);
  
     assertThat(vcfToBqContext.getInputFile()).matches(INPUT_FILE);
   }
@@ -74,10 +71,7 @@ public class VcfToBqContextTest {
  
   @Test
   public void testVcfContext_whenGetOutput_thenMatches() throws IOException {
-    VcfToBqOptions mockedVcfToBqOptions = create_mockedVcfToBqOptions(
-        INPUT_FILE,
-        OUTPUT);
-    VcfToBqContext vcfToBqContext = new VcfToBqContext(mockedVcfToBqOptions);   
+    VcfToBqContext vcfToBqContext = new VcfToBqContext(MOCKED_VCFTOBQ_OPTIONS);   
  
     assertThat(vcfToBqContext.getOutput()).matches(OUTPUT);
   }
@@ -94,10 +88,7 @@ public class VcfToBqContextTest {
  
  @Test
  public void testVcfContext_whenSetHeaderLines_thenMatches() throws IOException {
-    VcfToBqOptions mockedVcfToBqOptions = create_mockedVcfToBqOptions(
-        INPUT_FILE,
-        OUTPUT);
-    VcfToBqContext vcfToBqContext = new VcfToBqContext(mockedVcfToBqOptions);   
+    VcfToBqContext vcfToBqContext = new VcfToBqContext(MOCKED_VCFTOBQ_OPTIONS);   
     ImmutableList<String> headerLines = createHeaderLines();
     vcfToBqContext.setHeaderLines(headerLines);
  
@@ -106,10 +97,7 @@ public class VcfToBqContextTest {
  
   @Test
   public void testVcfContext_whenSetHeaderLines_thenNull() throws IOException {
-    VcfToBqOptions mockedVcfToBqOptions = create_mockedVcfToBqOptions(
-        INPUT_FILE,
-        OUTPUT);
-    VcfToBqContext vcfToBqContext = new VcfToBqContext(mockedVcfToBqOptions);   
+    VcfToBqContext vcfToBqContext = new VcfToBqContext(MOCKED_VCFTOBQ_OPTIONS);   
     vcfToBqContext.setHeaderLines(null);
  
     assertThat(vcfToBqContext.getHeaderLines()).isNull();
@@ -117,10 +105,7 @@ public class VcfToBqContextTest {
  
   @Test
   public void testVcfContext_whenGetHeaderLines_thenNull() throws IOException {
-    VcfToBqOptions mockedVcfToBqOptions = create_mockedVcfToBqOptions(
-        INPUT_FILE,
-        OUTPUT);
-    VcfToBqContext vcfToBqContext = new VcfToBqContext(mockedVcfToBqOptions);   
+    VcfToBqContext vcfToBqContext = new VcfToBqContext(MOCKED_VCFTOBQ_OPTIONS);   
  
     assertThat(vcfToBqContext.getHeaderLines()).isNull();
   }


### PR DESCRIPTION
### VcfToBqContext.java Tests

```
.gradlew test
```

**Notes:**
- refactored AbstractContext.java and VcfToBqTask.java
  - moved FileSystem call to use Pipeline Options for easier testing 
- unit tests for vcfToBqContext 