### PR TITLE
VcfToBqTask unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ gradlew.bat
 # Ignore IntelliJ project files
 .idea
 gcp-variant-transforms-java.iml
+
+#Ignore VSCode files
+.vscode/

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ dependencies {
   testImplementation 'junit:junit:4.12'
   testImplementation 'org.junit.jupiter:junit-jupiter:5.4.2'
   testImplementation 'org.mockito:mockito-core:3.3.3'
+  testImplementation 'com.google.guiceberry:guiceberry:3.3.1'
 }
 
 task vcfToBq(type:JavaExec) {
@@ -59,5 +60,6 @@ test {
   // Print test results
   testLogging {
     events "passed", "skipped", "failed"
+    showStandardStreams = true
   }
 }

--- a/src/main/java/com/google/gcp_variant_transforms/options/AbstractContext.java
+++ b/src/main/java/com/google/gcp_variant_transforms/options/AbstractContext.java
@@ -10,7 +10,6 @@ import java.io.IOException;
 public abstract class AbstractContext {
 
   public AbstractContext(PipelineOptions options) {
-    configureFilesystems(options);
   }
 
   /**
@@ -20,8 +19,4 @@ public abstract class AbstractContext {
    */
   protected abstract void validateFlags() throws IOException;
 
-  /** configures filesystem to the corresponding options, regardless of task. */
-  private void configureFilesystems(PipelineOptions options) {
-    FileSystems.setDefaultPipelineOptions(options);
-  }
 }

--- a/src/main/java/com/google/gcp_variant_transforms/task/VcfToBqTask.java
+++ b/src/main/java/com/google/gcp_variant_transforms/task/VcfToBqTask.java
@@ -2,12 +2,15 @@
 
 package com.google.gcp_variant_transforms.task;
 
+import org.apache.beam.sdk.io.FileSystems;
+import org.apache.beam.sdk.options.PipelineOptions;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.google.gcp_variant_transforms.beam.PipelineRunner;
 import com.google.gcp_variant_transforms.library.HeaderReader;
 import com.google.gcp_variant_transforms.options.VcfToBqContext;
+import com.google.gcp_variant_transforms.options.VcfToBqOptions;
 
 import java.io.IOException;
 
@@ -19,21 +22,30 @@ public class VcfToBqTask implements Task {
   private final HeaderReader headerReader;
   private final PipelineRunner pipelineRunner;
   private final VcfToBqContext context;
+  private final PipelineOptions options;
 
   @Inject
   public VcfToBqTask(
         PipelineRunner pipelineRunner,
         HeaderReader headerReader,
-        VcfToBqContext context) throws IOException {
+        VcfToBqContext context,
+        VcfToBqOptions options) throws IOException {
     this.pipelineRunner = pipelineRunner;
     this.headerReader = headerReader;
     this.context = context;
+    this.options = (PipelineOptions) options;
   }
 
   @Override
   public void run() throws IOException {
+    setPipelineOptions(this.options);
     context.setHeaderLines(headerReader.getHeaderLines());
     pipelineRunner.runPipeline();
+  }
+
+  /** configures filesystem to the corresponding options, regardless of task. */
+  protected void setPipelineOptions(PipelineOptions options) {
+    FileSystems.setDefaultPipelineOptions(options);
   }
 
   public static void main(String[] args) throws IOException {

--- a/src/test/java/com/google/gcp_variant_transforms/TestEnv.java
+++ b/src/test/java/com/google/gcp_variant_transforms/TestEnv.java
@@ -1,0 +1,21 @@
+// Copyright 2020 Google LLC
+
+package com.google.gcp_variant_transforms;
+
+import com.google.gcp_variant_transforms.library.VcfParser;
+import com.google.gcp_variant_transforms.library.VcfParserImpl;
+import com.google.gcp_variant_transforms.task.Task;
+import com.google.gcp_variant_transforms.task.VcfToBqTask;
+import com.google.guiceberry.GuiceBerryModule;
+import com.google.inject.AbstractModule;
+
+public class TestEnv extends AbstractModule {
+  
+  @Override
+  protected void configure() {
+    install(new GuiceBerryModule());
+
+    bind(VcfParser.class).to(VcfParserImpl.class);
+    bind(Task.class).to(VcfToBqTask.class);
+  }
+}

--- a/src/test/java/com/google/gcp_variant_transforms/options/VcfToBqContextTest.java
+++ b/src/test/java/com/google/gcp_variant_transforms/options/VcfToBqContextTest.java
@@ -1,0 +1,130 @@
+// Copyright 2020 Google LLC
+ 
+package com.google.gcp_variant_transforms.options;
+ 
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+ 
+import com.google.common.collect.ImmutableList;
+import com.google.gcp_variant_transforms.options.VcfToBqContext;
+import java.io.IOException;
+import org.junit.Test;
+ 
+/**
+* Units tests for VcfToBqContext.java
+*/
+public class VcfToBqContextTest {
+ 
+ public VcfToBqOptions create_mockedVcfToBqOptions(String inputFile, String output) {
+   VcfToBqOptions mockedVcfToBqOptions = mock(VcfToBqOptions.class);
+   when(mockedVcfToBqOptions.getInputFile()).thenReturn(inputFile);
+   when(mockedVcfToBqOptions.getOutput()).thenReturn(output);
+   return mockedVcfToBqOptions;
+ }
+ 
+ public ImmutableList<String> createHeaderLines() {
+   ImmutableList.Builder<String> headerLinesBuilder = new ImmutableList.Builder<String>();
+   for (int i = 0; i < 10; i++) {
+     headerLinesBuilder.add("##sampleHeaderLine=" + i);
+   }
+   return headerLinesBuilder.build();
+ }
+ 
+ @Test
+ public void testVcfContextConstructor_whenCompareFields_thenMatches() throws IOException {
+   String inputFile = "sampleInputFile.txt";
+   String output = "sampleOutputFile.txt";
+   VcfToBqOptions mockedVcfToBqOptions = create_mockedVcfToBqOptions(inputFile, output);
+   VcfToBqContext vcfToBqContext = new VcfToBqContext(mockedVcfToBqOptions);
+ 
+   assertThat(vcfToBqContext.getInputFile()).matches(inputFile);
+   assertThat(vcfToBqContext.getOutput()).matches(output);
+   assertThat(vcfToBqContext.getHeaderLines()).isNull();
+ }
+ 
+ @Test
+ public void testVcfContext_whenValidateFlags_thenException(){
+   VcfToBqOptions mockedVcfToBqOptions = create_mockedVcfToBqOptions(null, null);
+   
+   assertThrows(IOException.class, () ->
+       new VcfToBqContext(mockedVcfToBqOptions)); 
+ }
+ 
+ @Test
+ public void testVcfContext_whenGetInputFile_thenMatches() throws IOException {
+   String inputFile = "sampleInputFile.txt";
+   VcfToBqOptions mockedVcfToBqOptions = create_mockedVcfToBqOptions(
+       inputFile,
+       "sampleOutputFile.txt");
+   VcfToBqContext vcfToBqContext = new VcfToBqContext(mockedVcfToBqOptions);
+ 
+   assertThat(vcfToBqContext.getInputFile()).matches(inputFile);
+ }
+ 
+ @Test
+ public void testVcfContext_whenInputFileNull_thenNull() throws IOException {
+   VcfToBqOptions mockedVcfToBqOptions = create_mockedVcfToBqOptions(
+       null,
+       "sampleOutputFile.txt");
+   VcfToBqContext vcfToBqContext = new VcfToBqContext(mockedVcfToBqOptions);
+  
+   assertThat(vcfToBqContext.getInputFile()).isNull();
+ 
+ }
+ 
+ @Test
+ public void testVcfContext_whenGetOutput_thenMatches() throws IOException {
+   String output = "sampleOutputFile.txt";
+   VcfToBqOptions mockedVcfToBqOptions = create_mockedVcfToBqOptions(
+       "sampleInputFile.txt",
+       output);
+   VcfToBqContext vcfToBqContext = new VcfToBqContext(mockedVcfToBqOptions);   
+ 
+   assertThat(vcfToBqContext.getOutput()).matches(output);
+ }
+ 
+ @Test
+ public void testVcfContext_whenNullOutput_thenException() throws IOException {
+   VcfToBqOptions mockedVcfToBqOptions = create_mockedVcfToBqOptions(
+       "sampleInputFile.txt",
+       null);
+ 
+   assertThrows(IOException.class, () ->
+       new VcfToBqContext(mockedVcfToBqOptions));   
+ }
+ 
+ @Test
+ public void testVcfContext_whenSetHeaderLines_thenMatches() throws IOException {
+   VcfToBqOptions mockedVcfToBqOptions = create_mockedVcfToBqOptions(
+       "sampleInputFile.txt",
+       "sampleOutputFile.txt");
+   VcfToBqContext vcfToBqContext = new VcfToBqContext(mockedVcfToBqOptions);   
+   ImmutableList<String> headerLines = createHeaderLines();
+   vcfToBqContext.setHeaderLines(headerLines);
+ 
+   assertThat(vcfToBqContext.getHeaderLines()).containsExactlyElementsIn(headerLines);
+ }
+ 
+ @Test
+ public void testVcfContext_whenSetHeaderLines_thenNull() throws IOException {
+   VcfToBqOptions mockedVcfToBqOptions = create_mockedVcfToBqOptions(
+       "sampleInputFile.txt",
+       "sampleOutputFile.txt");
+   VcfToBqContext vcfToBqContext = new VcfToBqContext(mockedVcfToBqOptions);   
+   vcfToBqContext.setHeaderLines(null);
+ 
+   assertThat(vcfToBqContext.getHeaderLines()).isNull();
+ }
+ 
+ @Test
+ public void testVcfContext_whenGetHeaderLines_thenNull() throws IOException {
+   VcfToBqOptions mockedVcfToBqOptions = create_mockedVcfToBqOptions(
+       "sampleInputFile.txt",
+       "sampleOutputFile.txt");
+   VcfToBqContext vcfToBqContext = new VcfToBqContext(mockedVcfToBqOptions);   
+ 
+   assertThat(vcfToBqContext.getHeaderLines()).isNull();
+ }
+}

--- a/src/test/java/com/google/gcp_variant_transforms/task/VcfToBqTaskTest.java
+++ b/src/test/java/com/google/gcp_variant_transforms/task/VcfToBqTaskTest.java
@@ -1,0 +1,112 @@
+// Copyright 2020 Google LLC
+
+package com.google.gcp_variant_transforms.task;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import com.google.common.collect.ImmutableList;
+import com.google.gcp_variant_transforms.beam.PipelineRunner;
+import com.google.gcp_variant_transforms.library.HeaderReader;
+import com.google.gcp_variant_transforms.options.VcfToBqContext;
+import com.google.gcp_variant_transforms.options.VcfToBqOptions;
+import com.google.inject.Injector;
+import java.io.IOException;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Mock;
+
+/**
+ * Units tests for VcfToBqTask.java
+ */
+ public class VcfToBqTaskTest {
+  Injector spyInjector;
+  VcfToBqTask vcfToBqTask;
+  VcfToBqTask spyVcfToBqTask;
+
+  @Mock
+  PipelineRunner mockedPipelineRunner;
+
+  @Mock
+  VcfToBqOptions mockedVcfToBqOptions;
+
+  @Mock 
+  VcfToBqContext mockedVcfToBqContext;
+
+  @Mock
+  HeaderReader mockedHeaderReader;
+
+  @Captor
+  ArgumentCaptor<PipelineOptions> argCaptorPipelineOptions;
+
+  @Captor
+  ArgumentCaptor<ImmutableList<String>> argCaptorImmutableList;
+
+  @Before
+  public void initializeSpyAndMocks() throws IOException{
+    MockitoAnnotations.initMocks(this);
+    vcfToBqTask = new VcfToBqTask(
+        mockedPipelineRunner, 
+        mockedHeaderReader, 
+        mockedVcfToBqContext, 
+        mockedVcfToBqOptions);
+    spyVcfToBqTask = spy(vcfToBqTask);
+  }
+
+  public void setUpRunBehaviors() throws IOException {
+    ImmutableList.Builder<String> headerLinesBuilder = new ImmutableList.Builder<String>();
+    for (int i = 0; i < 5; i++) {
+      headerLinesBuilder.add("##sampleHeaderLine=" + i);
+    }
+    ImmutableList<String> headerLines = headerLinesBuilder.build();
+    doReturn(headerLines).when(mockedHeaderReader).getHeaderLines();
+    doNothing().when(spyVcfToBqTask).setPipelineOptions(argCaptorPipelineOptions.capture());
+    doNothing().when(mockedVcfToBqContext).setHeaderLines(argCaptorImmutableList.capture());
+    doNothing().when(mockedPipelineRunner).runPipeline();
+  }
+
+  @Test
+  public void testVcfTaskConstructor_whenInitialize_thenNotNull() throws IOException {
+    assertThat(vcfToBqTask).isNotNull();
+    assertThat(spyVcfToBqTask).isNotNull();
+  }
+
+  @Test
+  public void testVcfTask_whenRun_thenVerifySetPipelineOptions() throws IOException {
+    setUpRunBehaviors();
+    spyVcfToBqTask.run();
+
+    verify(spyVcfToBqTask).setPipelineOptions(mockedVcfToBqOptions);    
+  }
+
+  @Test
+  public void testVcfTask_whenRun_thenVerifySetHeaderLines() throws IOException {
+    setUpRunBehaviors();
+    spyVcfToBqTask.run();
+
+    verify(mockedVcfToBqContext).setHeaderLines(argCaptorImmutableList.capture());  
+  }
+
+  @Test
+  public void testVcfTask_whenRun_thenVerifyRunPipeline() throws IOException {
+    setUpRunBehaviors();
+    spyVcfToBqTask.run();
+
+    verify(mockedPipelineRunner).runPipeline();  
+  }
+
+  @Test
+  public void testVcfTask_whenSetPipelineOptions_thenVerify() throws Exception {
+    doNothing().when(spyVcfToBqTask).setPipelineOptions(argCaptorPipelineOptions.capture());;
+    spyVcfToBqTask.setPipelineOptions(mockedVcfToBqOptions);
+
+    verify(spyVcfToBqTask).setPipelineOptions(argCaptorPipelineOptions.capture());
+  }
+}


### PR DESCRIPTION
### Unit tests for VcfToBqTask.java:
- tests VcfToBqTask constructor
- tests run()
  - verifies that the 3 function calls inside run() are executed 
- tests setPipelineOptions()
  - verifies that setPipelineOptions() is callable
  - does **not** test static function FileSystems.setDefaultPipelineOptions()
- does **not** test static main(), which runs a static function to create injector and get injector instance
