### PR TITLE
VcfHeader generated in VcfParserImpl

### DIFF
--- a/src/main/java/com/google/gcp_variant_transforms/library/VcfParser.java
+++ b/src/main/java/com/google/gcp_variant_transforms/library/VcfParser.java
@@ -4,6 +4,7 @@ package com.google.gcp_variant_transforms.library;
 
 import com.google.common.collect.ImmutableList;
 import htsjdk.variant.vcf.VCFCodec;
+import htsjdk.variant.vcf.VCFHeader;
 import java.io.Serializable;
 
 /**
@@ -19,4 +20,6 @@ public interface VcfParser extends Serializable {
    * @return {@link VCFCodec}, preset with header lines, to parse records one at a time.
    */
   public abstract VCFCodec generateCodecFromHeaderLines(ImmutableList<String> headerLines);
+
+  public abstract VCFHeader generateVCFHeader(ImmutableList<String> headerLines);
 }

--- a/src/main/java/com/google/gcp_variant_transforms/library/VcfParserImpl.java
+++ b/src/main/java/com/google/gcp_variant_transforms/library/VcfParserImpl.java
@@ -5,6 +5,7 @@ package com.google.gcp_variant_transforms.library;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Singleton;
 import htsjdk.variant.vcf.VCFCodec;
+import htsjdk.variant.vcf.VCFHeader;
 
 /** Implementation of {@link VcfParser} service. */
 @Singleton
@@ -17,5 +18,12 @@ public class VcfParserImpl implements VcfParser {
     VCFCodec vcfCodec = new VCFCodec();
     vcfCodec.readActualHeader(new HeaderIterator(headerLines));
     return vcfCodec;
+  }
+
+  @Override
+  public VCFHeader generateVCFHeader(ImmutableList<String> headerLines){
+    VCFCodec vcfCodec = new VCFCodec();
+    vcfCodec.readActualHeader(new HeaderIterator(headerLines));
+    return vcfCodec.getHeader();
   }
 }

--- a/src/main/java/com/google/gcp_variant_transforms/options/VcfToBqContext.java
+++ b/src/main/java/com/google/gcp_variant_transforms/options/VcfToBqContext.java
@@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.gcp_variant_transforms.task.VcfToBqTask;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import htsjdk.variant.vcf.VCFHeader;
 import org.apache.beam.sdk.options.PipelineOptions;
 import java.io.IOException;
 
@@ -16,6 +17,7 @@ public class VcfToBqContext extends AbstractContext {
   private final String inputFile;
   private final String output;
   private ImmutableList<String> headerLines = null;
+  private VCFHeader vcfHeader = null;
 
   @Inject
   public VcfToBqContext(VcfToBqOptions options) throws IOException {
@@ -47,5 +49,13 @@ public class VcfToBqContext extends AbstractContext {
 
   public ImmutableList<String> getHeaderLines() {
     return headerLines;
+  }
+
+  public VCFHeader getVCFHeader(){
+    return vcfHeader;
+  }
+
+  public void setVCFHeader(VCFHeader vcfHeader){
+    this.vcfHeader = vcfHeader;
   }
 }

--- a/src/main/java/com/google/gcp_variant_transforms/task/VcfToBqTask.java
+++ b/src/main/java/com/google/gcp_variant_transforms/task/VcfToBqTask.java
@@ -7,6 +7,7 @@ import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.google.gcp_variant_transforms.beam.PipelineRunner;
 import com.google.gcp_variant_transforms.library.HeaderReader;
+import com.google.gcp_variant_transforms.library.VcfParser;
 import com.google.gcp_variant_transforms.options.VcfToBqContext;
 
 import java.io.IOException;
@@ -19,20 +20,24 @@ public class VcfToBqTask implements Task {
   private final HeaderReader headerReader;
   private final PipelineRunner pipelineRunner;
   private final VcfToBqContext context;
+  private final VcfParser parser;
 
   @Inject
   public VcfToBqTask(
         PipelineRunner pipelineRunner,
         HeaderReader headerReader,
-        VcfToBqContext context) throws IOException {
+        VcfToBqContext context,
+        VcfParser parser) throws IOException {
     this.pipelineRunner = pipelineRunner;
     this.headerReader = headerReader;
     this.context = context;
+    this.parser = parser;
   }
 
   @Override
   public void run() throws IOException {
     context.setHeaderLines(headerReader.getHeaderLines());
+    context.setVCFHeader(parser.generateVCFHeader(context.getHeaderLines()));
     pipelineRunner.runPipeline();
   }
 

--- a/src/test/java/com/google/gcp_variant_transforms/library/VcfParserImplTest.java
+++ b/src/test/java/com/google/gcp_variant_transforms/library/VcfParserImplTest.java
@@ -11,6 +11,7 @@ import com.google.guiceberry.junit4.GuiceBerryRule;
 import com.google.inject.Inject;
 import htsjdk.tribble.TribbleException;
 import htsjdk.variant.vcf.VCFCodec;
+import htsjdk.variant.vcf.VCFHeader;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -66,5 +67,32 @@ public class VcfParserImplTest {
 
     assertThat(invalidHeaderException).hasMessageThat()
           .contains("there are not enough columns present in the header line");
+  }
+
+  @Test
+  public void testGenerateVCFHeader_withoutHeaderLine_thenThrowException() {
+    // Invalid VCF header line format will throw TribbleException.InvalidHeader exception
+    Exception invalidHeaderException = assertThrows(TribbleException.class, () ->
+          vcfParser.generateVCFHeader(ImmutableList.of(FILE_FORMAT, INVALID_HEADER)));
+
+    assertThat(invalidHeaderException).hasMessageThat()
+          .contains("there are not enough columns present in the header line");
+  }
+
+  @Test
+  public void testGenerateVCFHeader_whenCheckFunctionCall_thenTrue() {
+    VCFHeader vcfHeader = vcfParser.generateVCFHeader(ImmutableList.of(FILE_FORMAT, VALID_HEADER));
+
+    assertThat(vcfHeader).isNotNull();
+  }
+
+  @Test
+  public void testGenerateVCFHeader_withoutVcfVersion_thenThrowException() {
+    // without specifying VCF version will throw TribbleException.InvalidHeader exception
+    Exception invalidHeaderException = assertThrows(TribbleException.class, () ->
+          vcfParser.generateVCFHeader(ImmutableList.of(FILE_DATE, VALID_HEADER)));
+
+    assertThat(invalidHeaderException).hasMessageThat()
+          .contains("We never saw a header line specifying VCF version");
   }
 }

--- a/src/test/java/com/google/gcp_variant_transforms/options/VcfToBqContextTest.java
+++ b/src/test/java/com/google/gcp_variant_transforms/options/VcfToBqContextTest.java
@@ -38,7 +38,7 @@ public class VcfToBqContextTest {
   }
  
   @Test
-  public void testVcfContextConstructor_whenCompareFields_thenMatches() throws IOException {
+  public void testVcfContextConstructor_whenCompareFields_thenIsEqualTo() throws IOException {
     VcfToBqContext vcfToBqContext = new VcfToBqContext(MOCKED_VCF_TO_BQ_OPTIONS);
  
     assertThat(vcfToBqContext.getInputFile()).matches(INPUT_FILE);
@@ -128,5 +128,4 @@ public class VcfToBqContextTest {
   
      assertThat(vcfToBqContext.getVCFHeader()).isNotNull();
    }
-
 }

--- a/src/test/java/com/google/gcp_variant_transforms/options/VcfToBqContextTest.java
+++ b/src/test/java/com/google/gcp_variant_transforms/options/VcfToBqContextTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
  
 import com.google.common.collect.ImmutableList;
+import htsjdk.variant.vcf.VCFHeader;
 import java.io.IOException;
 import org.junit.Test;
  
@@ -43,6 +44,7 @@ public class VcfToBqContextTest {
     assertThat(vcfToBqContext.getInputFile()).matches(INPUT_FILE);
     assertThat(vcfToBqContext.getOutput()).matches(OUTPUT);
     assertThat(vcfToBqContext.getHeaderLines()).isNull();
+    assertThat(vcfToBqContext.getVCFHeader()).isNull();
  }
  
   @Test
@@ -110,4 +112,21 @@ public class VcfToBqContextTest {
  
     assertThat(vcfToBqContext.getHeaderLines()).isNull();
   }
+
+  @Test
+  public void testVcfContext_whenGetVCFHeader_thenNull() throws IOException {
+    VcfToBqContext vcfToBqContext = new VcfToBqContext(MOCKED_VCF_TO_BQ_OPTIONS);   
+ 
+    assertThat(vcfToBqContext.getVCFHeader()).isNull();
+  }
+
+  @Test
+  public void testVcfContext_whenSetVCFHeader_thenNotNull() throws IOException {
+     VcfToBqContext vcfToBqContext = new VcfToBqContext(MOCKED_VCF_TO_BQ_OPTIONS);   
+     VCFHeader vcfHeader = mock(VCFHeader.class);
+     vcfToBqContext.setVCFHeader(vcfHeader);
+  
+     assertThat(vcfToBqContext.getVCFHeader()).isNotNull();
+   }
+
 }

--- a/src/test/java/com/google/gcp_variant_transforms/options/VcfToBqContextTest.java
+++ b/src/test/java/com/google/gcp_variant_transforms/options/VcfToBqContextTest.java
@@ -121,11 +121,11 @@ public class VcfToBqContextTest {
   }
 
   @Test
-  public void testVcfContext_whenSetVCFHeader_thenNotNull() throws IOException {
+  public void testVcfContext_whenSetVCFHeader_thenIsEqualTo() throws IOException {
      VcfToBqContext vcfToBqContext = new VcfToBqContext(MOCKED_VCF_TO_BQ_OPTIONS);   
      VCFHeader vcfHeader = mock(VCFHeader.class);
      vcfToBqContext.setVCFHeader(vcfHeader);
   
-     assertThat(vcfToBqContext.getVCFHeader()).isNotNull();
+     assertThat(vcfToBqContext.getVCFHeader()).isEqualTo(vcfHeader);
    }
 }

--- a/src/test/java/com/google/gcp_variant_transforms/options/VcfToBqContextTest.java
+++ b/src/test/java/com/google/gcp_variant_transforms/options/VcfToBqContextTest.java
@@ -73,10 +73,10 @@ public class VcfToBqContextTest {
   }
  
   @Test
-  public void testVcfContext_whenGetOutput_thenMatches() throws IOException {
+  public void testVcfContext_whenGetOutput_thenIsEqualTo() throws IOException {
     VcfToBqContext vcfToBqContext = new VcfToBqContext(MOCKED_VCF_TO_BQ_OPTIONS);   
  
-    assertThat(vcfToBqContext.getOutput()).matches(OUTPUT);
+    assertThat(vcfToBqContext.getOutput()).isEqualTo(OUTPUT);
   }
  
   @Test
@@ -90,7 +90,7 @@ public class VcfToBqContextTest {
   }
  
  @Test
- public void testVcfContext_whenSetHeaderLines_thenMatches() throws IOException {
+ public void testVcfContext_whenSetHeaderLines_thenIsEqualTo() throws IOException {
     VcfToBqContext vcfToBqContext = new VcfToBqContext(MOCKED_VCF_TO_BQ_OPTIONS);   
     ImmutableList<String> headerLines = createHeaderLines();
     vcfToBqContext.setHeaderLines(headerLines);


### PR DESCRIPTION
### Added a private VCFHeader object to VcfParserImpl.
- included getter to retrieve the VCFHeader wherever Parser is injected
- added two functions to create the VCFHeader using headerlines

#### Note: the header object is an instance from HTSJDK VCFHeader.java
