### PR TITLE
VariantContext to BQ row

### DIFF
--- a/src/main/java/com/google/gcp_variant_transforms/beam/VcfToBqPipelineRunner.java
+++ b/src/main/java/com/google/gcp_variant_transforms/beam/VcfToBqPipelineRunner.java
@@ -2,18 +2,22 @@
 
 package com.google.gcp_variant_transforms.beam;
 
+import com.google.api.services.bigquery.model.TableRow;
+import com.google.gcp_variant_transforms.beam.helper.ConvertVariantToRowFn;
+import com.google.gcp_variant_transforms.library.BigQueryRowGenerator;
 import com.google.inject.Inject;
 import com.google.gcp_variant_transforms.beam.helper.ConvertLineToVariantFn;
-import com.google.gcp_variant_transforms.entity.Variant;
 import com.google.gcp_variant_transforms.library.VcfParser;
 import com.google.gcp_variant_transforms.options.VcfToBqContext;
 import com.google.gcp_variant_transforms.options.VcfToBqOptions;
+import htsjdk.variant.variantcontext.VariantContext;
 import org.apache.beam.sdk.io.TextIO;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.transforms.Filter;
 import org.apache.beam.sdk.transforms.MapElements;
 import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.TypeDescriptors;
 
 public final class VcfToBqPipelineRunner implements PipelineRunner {
@@ -21,27 +25,37 @@ public final class VcfToBqPipelineRunner implements PipelineRunner {
   private final VcfToBqContext context;
   private final PipelineOptions options;
   private final VcfParser vcfParser;
+  private final BigQueryRowGenerator bigQueryRowGenerator;
 
   /** Implementation of {@link PipelineRunner} service. */
   @Inject
   public VcfToBqPipelineRunner(
-      VcfToBqContext context, VcfToBqOptions options, VcfParser vcfParser) {
+      VcfToBqContext context, VcfToBqOptions options, VcfParser vcfParser,
+      BigQueryRowGenerator bigQueryRowGenerator) {
     this.context = context;
     this.options = (PipelineOptions) options;
     this.vcfParser = vcfParser;
+    this.bigQueryRowGenerator = bigQueryRowGenerator;
   }
 
   public void runPipeline() {
     // Demo code.
     Pipeline pipeline = Pipeline.create(options);
-    pipeline.apply(TextIO.read().from(context.getInputFile()))
+    PCollection<VariantContext> variantContextPCollection =
+            pipeline.apply(TextIO.read().from(context.getInputFile()))
       .apply(Filter.by((String inputLine) -> !inputLine.startsWith("#")))
-      .apply(ParDo.of(new ConvertLineToVariantFn(vcfParser, context.getHeaderLines())))
-      .apply(
+      .apply(ParDo.of(new ConvertLineToVariantFn(vcfParser, context.getHeaderLines())));
+
+    PCollection<TableRow> tableRowPCollection = variantContextPCollection
+            .apply("VariantContextToBQRow",
+                    ParDo.of(new ConvertVariantToRowFn(bigQueryRowGenerator,
+                            context.getVCFHeader())));
+
+    variantContextPCollection.apply(
           MapElements
               .into(TypeDescriptors.strings())
               .via(
-                  (Variant variant) ->
+                  (VariantContext variant) ->
                   String.format("Contig: %s; Start: %d; End: %d",
                       variant.getContig(), variant.getStart(), variant.getEnd())))
       .apply(TextIO.write().to(context.getOutput()).withNoSpilling());

--- a/src/main/java/com/google/gcp_variant_transforms/beam/helper/ConvertLineToVariantFn.java
+++ b/src/main/java/com/google/gcp_variant_transforms/beam/helper/ConvertLineToVariantFn.java
@@ -3,17 +3,19 @@
 package com.google.gcp_variant_transforms.beam.helper;
 
 import com.google.common.collect.ImmutableList;
-import com.google.gcp_variant_transforms.entity.Variant;
 import com.google.gcp_variant_transforms.library.VcfParser;
+import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.vcf.VCFCodec;
+import htsjdk.variant.vcf.VCFHeader;
 import org.apache.beam.sdk.transforms.DoFn;
 
 /** {@link DoFn} implementation for decoding variant VCF lines into Variant objects. */
-public class ConvertLineToVariantFn extends DoFn<String, Variant> {
+public class ConvertLineToVariantFn extends DoFn<String, VariantContext> {
   private static final long serialVersionUID = -5248117228853194645L;
   private final VcfParser vcfParser;
   private final ImmutableList<String> headerLines;
   private VCFCodec vcfCodec = null;
+  private VCFHeader vcfHeader = null;
 
   public ConvertLineToVariantFn(VcfParser vcfParser, ImmutableList<String> headerLines) {
     this.vcfParser = vcfParser;
@@ -21,11 +23,12 @@ public class ConvertLineToVariantFn extends DoFn<String, Variant> {
   }
 
   @ProcessElement
-  public void processElement(@Element String record, OutputReceiver<Variant> receiver) {
+  public void processElement(@Element String record, OutputReceiver<VariantContext> receiver) {
     // Codec's are not Serializable, so they need to be generated directly on the worker machine.
     if (vcfCodec == null) {
       vcfCodec = vcfParser.generateCodecFromHeaderLines(headerLines);
+      vcfHeader = vcfCodec.getHeader();
     }
-    receiver.output(new Variant(vcfCodec.decode(record)));
+    receiver.output(vcfCodec.decode(record));
   }
 }

--- a/src/main/java/com/google/gcp_variant_transforms/beam/helper/ConvertVariantToRowFn.java
+++ b/src/main/java/com/google/gcp_variant_transforms/beam/helper/ConvertVariantToRowFn.java
@@ -1,0 +1,27 @@
+// Copyright 2020 Google LLC
+
+package com.google.gcp_variant_transforms.beam.helper;
+
+import com.google.api.services.bigquery.model.TableRow;
+import com.google.gcp_variant_transforms.library.BigQueryRowGenerator;
+import htsjdk.variant.variantcontext.VariantContext;
+import htsjdk.variant.vcf.VCFHeader;
+import org.apache.beam.sdk.transforms.DoFn;
+
+/** {@link DoFn} implementation for a VariantContext to a BigQuery Row. */
+public class ConvertVariantToRowFn extends DoFn<VariantContext, TableRow> {
+  private final boolean allowIncompatibleRecords = false;
+  private final boolean omitEmptySampleCalls = false;
+  private BigQueryRowGenerator bigQueryRowGenerator;
+  private VCFHeader vcfHeader;
+
+  public ConvertVariantToRowFn(VCFHeader vcfHeader, BigQueryRowGenerator bigQueryRowGenerator) {
+    this.bigQueryRowGenerator = bigQueryRowGenerator;
+    this.vcfHeader = vcfHeader;
+  }
+
+  @ProcessElement
+  public void processElement(@Element VariantContext variantContext, OutputReceiver<TableRow> receiver) {
+    receiver.output(bigQueryRowGenerator.getRows(variantContext, vcfHeader));
+  }
+}

--- a/src/main/java/com/google/gcp_variant_transforms/library/BigQueryRowGenerator.java
+++ b/src/main/java/com/google/gcp_variant_transforms/library/BigQueryRowGenerator.java
@@ -1,0 +1,18 @@
+// Copyright 2020 Google LLC
+
+package com.google.gcp_variant_transforms.library;
+
+import com.google.api.services.bigquery.model.TableRow;
+import htsjdk.variant.variantcontext.VariantContext;
+import htsjdk.variant.vcf.VCFHeader;
+
+/**
+ * Service to generate Big Query Row from VariantContext
+ */
+public interface BigQueryRowGenerator {
+  /**
+   * BigQuery row generator. It provides the common functionalities when generating BigQuery
+   * row (e.g., sanitizing the BigQuery field, resolving the conflicts between the schema and data).
+   */
+  public TableRow getRows(VariantContext variantContext, VCFHeader vcfHeader);
+}

--- a/src/main/java/com/google/gcp_variant_transforms/library/BigQueryRowGeneratorImpl.java
+++ b/src/main/java/com/google/gcp_variant_transforms/library/BigQueryRowGeneratorImpl.java
@@ -1,0 +1,52 @@
+// Copyright 2020 Google LLC
+
+package com.google.gcp_variant_transforms.library;
+
+import com.google.api.services.bigquery.model.TableRow;
+import htsjdk.variant.variantcontext.GenotypesContext;
+import htsjdk.variant.variantcontext.VariantContext;
+import htsjdk.variant.vcf.VCFHeader;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Base abstract class for BigQuery row generator.
+ * The base class provides the common functionalities when generating BigQuery
+ * row (e.g., sanitizing the BigQuery field, resolving the conflicts between the schema and data).
+ * Derived classes must implement "get_rows".
+ */
+public class BigQueryRowGeneratorImpl implements BigQueryRowGenerator{
+
+  public TableRow getRows(VariantContext variantContext, VCFHeader vcfHeader) {
+    TableRow row = new TableRow();
+
+    row.set(VariantToBqUtils.ColumnKeyConstants.REFERENCE_NAME, variantContext.getContig());
+    row.set(VariantToBqUtils.ColumnKeyConstants.START_POSITION, variantContext.getStart());
+    row.set(VariantToBqUtils.ColumnKeyConstants.END_POSITION, variantContext.getEnd());
+    row.set(VariantToBqUtils.ColumnKeyConstants.REFERENCE_BASES,
+            VariantToBqUtils.buildReferenceBase(variantContext));
+    row.set(VariantToBqUtils.ColumnKeyConstants.NAMES, variantContext.getID());
+
+    // write alt field and info field to BQ row
+    List<TableRow> altMetadata = VariantToBqUtils.addAlternates(variantContext);
+    // altMeta should add those field that info number = 'A', then add to row
+    // Other fields will directly add to the base BQ row
+    VariantToBqUtils.addInfo(row, variantContext, altMetadata, vcfHeader);
+    row.set(VariantToBqUtils.ColumnKeyConstants.ALTERNATE_BASES, altMetadata);
+
+    row.set(VariantToBqUtils.ColumnKeyConstants.QUALITY, variantContext.getPhredScaledQual());
+
+    Set<String> filters = variantContext.getFilters();
+    if (filters.isEmpty()) {
+      filters.add("PASS");
+    }
+    row.set(VariantToBqUtils.ColumnKeyConstants.FILTER, filters);
+
+    // write calls to BQ row
+    GenotypesContext genotypesContext = variantContext.getGenotypes();
+    List<TableRow> callRows = VariantToBqUtils.addCalls(genotypesContext, vcfHeader);
+    row.set(VariantToBqUtils.ColumnKeyConstants.CALLS, callRows);
+
+    return row;
+  }
+}

--- a/src/main/java/com/google/gcp_variant_transforms/library/VariantToBqUtils.java
+++ b/src/main/java/com/google/gcp_variant_transforms/library/VariantToBqUtils.java
@@ -1,0 +1,224 @@
+// Copyright 2020 Google LLC
+
+package com.google.gcp_variant_transforms.library;
+
+import com.google.api.services.bigquery.model.TableRow;
+import htsjdk.variant.variantcontext.Allele;
+import htsjdk.variant.variantcontext.Genotype;
+import htsjdk.variant.variantcontext.GenotypesContext;
+import htsjdk.variant.variantcontext.VariantContext;
+import htsjdk.variant.vcf.VCFHeader;
+import htsjdk.variant.vcf.VCFHeaderLineCount;
+import htsjdk.variant.vcf.VCFHeaderLineType;
+import htsjdk.variant.vcf.VCFInfoHeaderLine;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Utility constants and methods for write values with defined value type into Big Query rows.
+ */
+public class VariantToBqUtils {
+
+  private static final String MISSING_FIELD_VALUE = ".";
+  private static final String PHASESET_FORMAT_KEY = "PS";
+  private static final String DEFAULT_PHASESET = "*";
+  private static final int MISSING_GENOTYPE_VALUE = -1;
+
+  /**
+   * Constants for column names in the BigQuery schema.
+   */
+  public static class ColumnKeyConstants {
+    public static final String REFERENCE_NAME = "reference_name";
+    public static final String START_POSITION = "start_position";
+    public static final String END_POSITION = "end_position";
+    public static final String REFERENCE_BASES = "reference_bases";
+    public static final String ALTERNATE_BASES = "alternate_bases";
+    public static final String ALTERNATE_BASES_ALT = "alt";
+    public static final String NAMES = "names";
+    public static final String QUALITY = "quality";
+    public static final String FILTER = "filter";
+    public static final String CALLS = "call";
+    public static final String CALLS_NAME = "name";
+    public static final String CALLS_GENOTYPE = "genotype";
+    public static final String CALLS_PHASESET = "phaseset";
+  }
+
+  public static String buildReferenceBase(VariantContext variantContext) {
+    Allele referenceAllele = variantContext.getReference();
+    // If the ref length is longer than 1, store the ref as a String
+    return referenceAllele.getDisplayString();
+  }
+
+  public static List<TableRow> addAlternates(VariantContext variantContext) {
+    List<TableRow> altMetadata = new ArrayList<>();
+    List<Allele> altAlleles = variantContext.getAlternateAlleles();
+    for (Allele allele : altAlleles) {
+      TableRow subRow = new TableRow();
+      String altBase = allele.getDisplayString();
+      if (altBase.length() == 0) {
+        subRow.set(ColumnKeyConstants.ALTERNATE_BASES_ALT, null);
+      } else {
+        subRow.set(ColumnKeyConstants.ALTERNATE_BASES_ALT, altBase);
+      }
+      altMetadata.add(subRow);
+    }
+    return altMetadata;
+  }
+
+  /**
+   * Add variant Info field into BQ table row.
+   * If the info field number in the VCF header is `A`, add it to the ALT sub field.
+   */
+  public static void addInfo(TableRow row, VariantContext variantContext,
+                             List<TableRow> altMetadata, VCFHeader vcfHeader) {
+    Map<String, Object> info = new HashMap<>();
+    for (Map.Entry<String, Object> entry : variantContext.getAttributes().entrySet()) {
+      String attrName = entry.getKey();
+      Object value = entry.getValue();
+      VCFInfoHeaderLine infoMetadata = vcfHeader.getInfoHeaderLine(attrName);
+      VCFHeaderLineType infoType = infoMetadata.getType();
+      VCFHeaderLineCount infoCount = infoMetadata.getCountType();
+      if (infoCount == VCFHeaderLineCount.A) {
+        // put this info into ALT field
+        splitAlternateAlleleInfoFields(attrName, value, altMetadata, infoType);
+      } else {
+        row.set(attrName, convertToDefinedType(value, infoType));
+      }
+    }
+  }
+
+  public static List<TableRow> addCalls(GenotypesContext genotypes, VCFHeader vcfHeader) {
+    List<TableRow> callRows = new ArrayList<>();
+    for (Genotype genotype : genotypes) {
+      TableRow curRow = new TableRow();
+      curRow.set(ColumnKeyConstants.CALLS_NAME, genotype.getSampleName());
+      addInfoAndPhaseSet(curRow, genotype, vcfHeader);
+      addGenotypes(curRow, genotype.getAlleles());
+      callRows.add(curRow);
+    }
+    return callRows;
+  }
+
+  /**
+   * Convert the value to the type defined in the metadata
+   * If the value is an instance of List, iterate the list
+   * and call convertSingleObjectToDefinedType() to convert every value
+   */
+  public static Object convertToDefinedType(Object value, VCFHeaderLineType type) {
+    if (!(value instanceof List)) {
+      // deal with single value
+      // There are some field value is a single String with ',', eg: "HQ" ->"23,27"
+      // We need to convert it to list of String and call the convert function again
+      if ((value instanceof String) && ((String)value).contains(",")) {
+        String valueStr = (String)value;
+        return convertToDefinedType(Arrays.asList(valueStr.split(",")), type);
+      }
+      return convertSingleObjectToDefinedType(value, type);
+    } else {
+      // deal with list of values
+      List<Object> valueList = (List<Object>)value;
+      List<Object> convertedList = new ArrayList<>();
+      for (Object val : valueList) {
+        convertedList.add(convertSingleObjectToDefinedType(val, type));
+      }
+      return convertedList;
+    }
+  }
+  /**
+   * For a single value Object, convert to the type defined in the metadata
+   */
+  private static Object convertSingleObjectToDefinedType(Object value, VCFHeaderLineType type) {
+    // values and their types have already been parsed by VCFCodec.decode()
+    if (!(value instanceof String)) {
+      return value;
+    }
+
+    String valueStr = (String)value;
+    valueStr = valueStr.trim();   // for cases like " 27", ignore the space in list element
+
+    if (valueStr.equals(MISSING_FIELD_VALUE)) {
+      return null;
+    }
+
+    // double check if the String value match the type and also is a number
+    boolean isNumber = valueStr.matches("[-+]?\\d+(\\.\\d+)?");
+
+    if (type == VCFHeaderLineType.Integer && isNumber) {
+      return Integer.parseInt(valueStr);
+    } else if (type == VCFHeaderLineType.Float && isNumber) {
+      return Double.parseDouble(valueStr);
+    } else {
+      // default String value
+      return value;
+    }
+  }
+
+  private static void addGenotypes(TableRow row, List<Allele> alleles) {
+    List<Integer> genotypes = new ArrayList<>();
+    for (Allele allele : alleles) {
+      byte[] bases = allele.getDisplayBases();
+      if (bases.length == 0) {
+        // MISSING_VALUE is presented, should add -1
+        genotypes.add(MISSING_GENOTYPE_VALUE);
+      } else {
+        for (byte base : bases) {
+          genotypes.add((int)base);
+        }
+      }
+    }
+    row.set(ColumnKeyConstants.CALLS_GENOTYPE, genotypes);
+  }
+
+  private static void addInfoAndPhaseSet(TableRow row, Genotype genotype, VCFHeader vcfHeader) {
+    String phaseSet = "";
+
+    if (genotype.hasAD()) { row.set("AD", genotype.getAD()); }
+    if (genotype.hasDP()) { row.set("DP", genotype.getDP()); }
+    if (genotype.hasGQ()) { row.set("GQ", genotype.getGQ()); }
+    if (genotype.hasPL()) { row.set("PL", genotype.getPL()); }
+    Map<String, Object> extendedAttributes = genotype.getExtendedAttributes();
+    for (String extendedAttr : extendedAttributes.keySet()) {
+      if (extendedAttr.equals(PHASESET_FORMAT_KEY)) {
+        String phaseSetValue = extendedAttributes.get(PHASESET_FORMAT_KEY).toString();
+        phaseSet = dealWithMissingFieldValue(phaseSetValue);
+      } else {
+        // The rest of fields need to be converted to the right type by VCFCodec decode function
+        row.set(extendedAttr, convertToDefinedType(extendedAttributes.get(extendedAttr),
+                vcfHeader.getFormatHeaderLine(extendedAttr).getType()));
+      }
+    }
+    if (phaseSet == null || phaseSet.length() != 0) {
+      // phaseSet is presented(MISSING_FIELD_VALUE('.') or real value)
+      row.set(ColumnKeyConstants.CALLS_PHASESET, phaseSet);
+    } else {
+      row.set(ColumnKeyConstants.CALLS_PHASESET, DEFAULT_PHASESET);
+    }
+  }
+
+
+  /**
+   * In some fields that values are MISSING_FIELD_VALUE('.'), should set null in BQ row.
+   */
+  private static String dealWithMissingFieldValue(String value) {
+    return value.equals(MISSING_FIELD_VALUE) ? null : value;
+  }
+
+  private static void splitAlternateAlleleInfoFields(String attrName, Object value,
+                                                     List<TableRow> altMetadata,
+                                                     VCFHeaderLineType type) {
+    if (value instanceof List && altMetadata.size() > 1) {
+      // The alt field element size > 1, thus the value should be list and the size should be equal
+      // to the alt field size
+      List<Object> valList = (List<Object>)value;
+      for (int i = 0; i < altMetadata.size(); ++i) {
+        altMetadata.get(i).set(attrName, convertSingleObjectToDefinedType(valList.get(i), type));
+      }
+    } else {
+      // The alt field element size == 1, thus the value should be a single list
+      altMetadata.get(0).set(attrName, convertSingleObjectToDefinedType(value, type));
+    }
+  }
+}

--- a/src/test/java/com/google/gcp_variant_transforms/library/VariantToBqUtilsTest.java
+++ b/src/test/java/com/google/gcp_variant_transforms/library/VariantToBqUtilsTest.java
@@ -1,0 +1,42 @@
+// Copyright 2020 Google LLC
+
+package com.google.gcp_variant_transforms.library;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import htsjdk.variant.vcf.VCFHeaderLineType;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+/**
+ * Units tests for VariantToBqUtils.java
+ */
+public class VariantToBqUtilsTest {
+
+  @Test
+  public void testConvertStringValueToRightValueType_whenComparingElement_thenTrue() {
+    // test list of values
+    String integerListStr = "23,27";
+    assertThat(VariantToBqUtils.convertToDefinedType(integerListStr, VCFHeaderLineType.Integer))
+            .isEqualTo(Arrays.asList(23, 27));
+    String floatListStr = "0.333,0.667";
+    assertThat(VariantToBqUtils.convertToDefinedType(floatListStr, VCFHeaderLineType.Float))
+            .isEqualTo(Arrays.asList(0.333, 0.667));
+
+    // test int values
+    String integerStr = "23";
+    assertThat(VariantToBqUtils.convertToDefinedType(integerStr, VCFHeaderLineType.Integer))
+            .isEqualTo(23);
+
+    // test float values
+    String floatStr = "0.333";
+    assertThat(VariantToBqUtils.convertToDefinedType(floatStr, VCFHeaderLineType.Float))
+            .isEqualTo(0.333);
+
+    // test String values
+    String str = "T";
+    assertThat(VariantToBqUtils.convertToDefinedType(str, VCFHeaderLineType.String))
+            .isEqualTo("T");
+  }
+}


### PR DESCRIPTION
From what we have discussed about the header, I have modified the code to get VCFHeader from context.  
Implementation:
In the **VcfToBqPipelineRunner**, I created a PCollection<TableRow> to generate TableRow, and I created a service interface **BigQueryRowGenerator** and implemented the TableRow generator.  
The utility functions to convert the value from VariantContext to the right value type are provided in the **VariantToBqUtils**.

Note:
As I have modified the code today and the header has not been added to the context yet(the context.getVCFHeader() is not implemented), I will add unit test for VariantContext to BQ in another separate PR later