### PR TITLE
Deal with Flag field not presented

### DIFF
--- a/src/main/java/com/google/gcp_variant_transforms/library/VariantToBqUtils.java
+++ b/src/main/java/com/google/gcp_variant_transforms/library/VariantToBqUtils.java
@@ -46,11 +46,19 @@ public interface VariantToBqUtils {
   public Set<String> getFilters(VariantContext variantContext);
 
   /**
-   * Add variant Info field into BQ table row. For each field value, check if the value size
-   * matches the count defined by VCFHeader and convert each value to the defined type.
-   * If the info field number in the VCF header is `A`, add it to the ALT sub field. The size for
-   * this field should be equal to the expected alternate bases count, which is the size of the
-   * alternate bases value.
+   * <p>
+   *  Add variant Info field into BQ table row. For each field in the VCFHeader, check if the
+   *  field is presented. If the field type is `Flag` but not presented, it will set `false` in
+   *  the row field.
+   * </p>
+   *
+   * <p>
+   *  Also check if the field value size matches the count defined by VCFHeader and convert each
+   *  value to the defined type. If the info field number in the VCF header is `A`, add it to
+   *  the ALT sub field. The size for this field should be equal to the expected alternate bases
+   *  count, which is the size of the alternate bases value.
+   * </p>
+   *
    * @param row Base TableRow for the VariantContext.
    * @param variantContext
    * @param altMetadata List of TableRow in the alternate bases repeated field.
@@ -69,10 +77,10 @@ public interface VariantToBqUtils {
 
   /**
    * <p>
-   * Convert object value to the {@link VCFHeader} defined type and count.
-   * If the value size does not match the count in the VCFHeader, it should raise an exception.
-   * For list of values, for each value,call `convertSingleObjectToDefinedType` to convert value
-   * to defined type.
+   *  Convert object value to the {@link VCFHeader} defined type and count.
+   *  If the value size does not match the count in the VCFHeader, it should raise an exception.
+   *  For list of values, for each value,call `convertSingleObjectToDefinedType` to convert value
+   *  to defined type.
    * </p>
    *
    * <p>

--- a/src/main/java/com/google/gcp_variant_transforms/library/VariantToBqUtilsImpl.java
+++ b/src/main/java/com/google/gcp_variant_transforms/library/VariantToBqUtilsImpl.java
@@ -77,10 +77,10 @@ public class VariantToBqUtilsImpl implements VariantToBqUtils, Serializable {
     // Iterate all Info field in VCFHeader, if current record does not have the field, skip it.
     for (VCFInfoHeaderLine infoHeaderLine : vcfHeader.getInfoHeaderLines()) {
       String attrName = infoHeaderLine.getID();
+      VCFInfoHeaderLine infoMetadata = vcfHeader.getInfoHeaderLine(attrName);
+      VCFHeaderLineType infoType = infoMetadata.getType();
       if (variantContext.hasAttribute(attrName)) {
         Object value = variantContext.getAttribute(attrName);
-        VCFInfoHeaderLine infoMetadata = vcfHeader.getInfoHeaderLine(attrName);
-        VCFHeaderLineType infoType = infoMetadata.getType();
         VCFHeaderLineCount infoCountType = infoMetadata.getCountType();
         if (infoCountType == VCFHeaderLineCount.A) {
             // Put this info into ALT field.
@@ -96,6 +96,10 @@ public class VariantToBqUtilsImpl implements VariantToBqUtils, Serializable {
           // count matches the expected count.
           row.set(attrName, convertToDefinedType(value, infoType, Constants.DEFAULT_FIELD_COUNT));
         }
+      } else if (infoType.equals(VCFHeaderLineType.Flag)) {
+        // If field is not presented in the VCF record and its field type is `Flag`, we need to
+        // set `false` in this field value.
+        row.set(attrName, false);
       }
     }
   }
@@ -190,36 +194,40 @@ public class VariantToBqUtilsImpl implements VariantToBqUtils, Serializable {
     String phaseSet = "";
     // Iterate all format fields in VCFHeader.
     for (VCFFormatHeaderLine formatHeaderLine : vcfHeader.getFormatHeaderLines()) {
-      String fieldName = formatHeaderLine.getID();
-      if (fieldName.equals(VCFConstants.GENOTYPE_KEY)) {
+      String attrName = formatHeaderLine.getID();
+      if (attrName.equals(VCFConstants.GENOTYPE_KEY)) {
         continue; // We will set GT field in a separate "genotype" field in BQ row.
       }
-      if (genotype.hasAnyAttribute(fieldName)) {
-        Object value = genotype.getAnyAttribute(fieldName);
-        if (fieldName.equals(VCFConstants.GENOTYPE_ALLELE_DEPTHS) ||
-            fieldName.equals(VCFConstants.DEPTH_KEY) ||
-            fieldName.equals(VCFConstants.GENOTYPE_QUALITY_KEY) ||
-            fieldName.equals(VCFConstants.GENOTYPE_PL_KEY)) {
+      VCFFormatHeaderLine formatMetadata = vcfHeader.getFormatHeaderLine(attrName);
+      VCFHeaderLineType formatType = formatMetadata.getType();
+      if (genotype.hasAnyAttribute(attrName)) {
+        Object value = genotype.getAnyAttribute(attrName);
+        if (attrName.equals(VCFConstants.GENOTYPE_ALLELE_DEPTHS) ||
+            attrName.equals(VCFConstants.DEPTH_KEY) ||
+            attrName.equals(VCFConstants.GENOTYPE_QUALITY_KEY) ||
+            attrName.equals(VCFConstants.GENOTYPE_PL_KEY)) {
           // These four field values have been pre-processed in Genotype.
-          row.set(fieldName, value);
-        } else if (fieldName.equals(VCFConstants.PHASE_SET_KEY)) {
+          row.set(attrName, value);
+        } else if (attrName.equals(VCFConstants.PHASE_SET_KEY)) {
           String phaseSetValue = genotype.getAnyAttribute(VCFConstants.PHASE_SET_KEY).toString();
           phaseSet = replaceMissingWithNull(phaseSetValue);
         } else {
           // The rest of fields need to be converted to the right type as VCFHeader specifies.
-          VCFFormatHeaderLine formatMetadata = vcfHeader.getFormatHeaderLine(fieldName);
-          VCFHeaderLineType formatType = formatMetadata.getType();
           VCFHeaderLineCount formatCountType = formatMetadata.getCountType();
           if (formatCountType == VCFHeaderLineCount.INTEGER) {
-            row.set(fieldName, convertToDefinedType(genotype.getAnyAttribute(fieldName),
+            row.set(attrName, convertToDefinedType(genotype.getAnyAttribute(attrName),
                 formatType, formatMetadata.getCount()));
           } else {
             // If field number in the VCFHeader is ".", should pass a default count and do not
             // check if count is equal to the size of value.
-            row.set(fieldName, convertToDefinedType(genotype.getAnyAttribute(fieldName),
+            row.set(attrName, convertToDefinedType(genotype.getAnyAttribute(attrName),
                 formatType, Constants.DEFAULT_FIELD_COUNT));
           }
         }
+      } else if (formatType.equals(VCFHeaderLineType.Flag)) {
+        // If field is not presented in the VCF record and its field type is `Flag`, we need to
+        // set `false` in this field value.
+        row.set(attrName, false);
       }
     }
     if (phaseSet == null || !phaseSet.isEmpty()) {

--- a/src/main/java/com/google/gcp_variant_transforms/library/VariantToBqUtilsImpl.java
+++ b/src/main/java/com/google/gcp_variant_transforms/library/VariantToBqUtilsImpl.java
@@ -198,10 +198,10 @@ public class VariantToBqUtilsImpl implements VariantToBqUtils, Serializable {
       if (attrName.equals(VCFConstants.GENOTYPE_KEY)) {
         continue; // We will set GT field in a separate "genotype" field in BQ row.
       }
-      VCFFormatHeaderLine formatMetadata = vcfHeader.getFormatHeaderLine(attrName);
-      VCFHeaderLineType formatType = formatMetadata.getType();
       if (genotype.hasAnyAttribute(attrName)) {
         Object value = genotype.getAnyAttribute(attrName);
+        VCFFormatHeaderLine formatMetadata = vcfHeader.getFormatHeaderLine(attrName);
+        VCFHeaderLineType formatType = formatMetadata.getType();
         if (attrName.equals(VCFConstants.GENOTYPE_ALLELE_DEPTHS) ||
             attrName.equals(VCFConstants.DEPTH_KEY) ||
             attrName.equals(VCFConstants.GENOTYPE_QUALITY_KEY) ||
@@ -224,10 +224,6 @@ public class VariantToBqUtilsImpl implements VariantToBqUtils, Serializable {
                 formatType, Constants.DEFAULT_FIELD_COUNT));
           }
         }
-      } else if (formatType.equals(VCFHeaderLineType.Flag)) {
-        // If field is not presented in the VCF record and its field type is `Flag`, we need to
-        // set `false` in this field value.
-        row.set(attrName, false);
       }
     }
     if (phaseSet == null || !phaseSet.isEmpty()) {

--- a/src/test/java/com/google/gcp_variant_transforms/library/BigQueryRowGeneratorTest.java
+++ b/src/test/java/com/google/gcp_variant_transforms/library/BigQueryRowGeneratorTest.java
@@ -12,6 +12,7 @@ import com.google.guiceberry.junit4.GuiceBerryRule;
 import com.google.inject.Inject;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.variant.vcf.VCFCodec;
+import htsjdk.variant.vcf.VCFConstants;
 import htsjdk.variant.vcf.VCFHeader;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -40,8 +41,8 @@ public class BigQueryRowGeneratorTest {
   private static final String TEST_ALTERNATE_BASES = "A";
   private static final String TEST_CALLS_NAME = "NA00003";
   private static final String DEFAULT_PHASE_SET = "*";
-  private static final boolean TEST_DB = true;
-  private static final boolean TEST_H2 = true;
+  private static final boolean TEST_FLAG_PRESENT = true;
+  private static final boolean TEST_FLAG_NOT_PRESENT = false;
   private static final double TEST_AF = 0.5;
   private static final double UNKNOWN_QUALITY = -10;
   private static final int TEST_START = 14370;
@@ -116,12 +117,14 @@ public class BigQueryRowGeneratorTest {
     TableRow altBase = altMetadata.get(0);
     assertThat(altBase.get(Constants.ColumnKeyNames.ALTERNATE_BASES_ALT))
         .isEqualTo(TEST_ALTERNATE_BASES);
-    assertThat(altBase.get("AF")).isEqualTo(TEST_AF);
+    assertThat(altBase.get(VCFConstants.ALLELE_FREQUENCY_KEY)).isEqualTo(TEST_AF);
 
-    assertThat(rowWithFieldValues.get("NS")).isEqualTo(TEST_NS);
-    assertThat(rowWithFieldValues.get("DP")).isEqualTo(TEST_DP);
-    assertThat(rowWithFieldValues.get("DB")).isEqualTo(TEST_DB);
-    assertThat(rowWithFieldValues.get("H2")).isEqualTo(TEST_H2);
+    assertThat(rowWithFieldValues.get(VCFConstants.SAMPLE_NUMBER_KEY)).isEqualTo(TEST_NS);
+    assertThat(rowWithFieldValues.get(VCFConstants.DEPTH_KEY)).isEqualTo(TEST_DP);
+    assertThat(rowWithFieldValues.get(VCFConstants.DBSNP_KEY)).isEqualTo(TEST_FLAG_PRESENT);
+
+    // For fields that type is "Flag", if it is not presented, it should be set as false.
+    assertThat(rowWithEmptyFields.get(VCFConstants.DBSNP_KEY)).isEqualTo(TEST_FLAG_NOT_PRESENT);
   }
 
   @Test
@@ -137,7 +140,8 @@ public class BigQueryRowGeneratorTest {
         .isEqualTo(DEFAULT_PHASE_SET);
     assertThat(rowWithMissingHQ.get(Constants.ColumnKeyNames.CALLS_GENOTYPE))
         .isEqualTo(Arrays.asList(TEST_GENOTYPE, TEST_GENOTYPE));
-    assertThat(rowWithMissingHQ.get("HQ")).isEqualTo(Arrays.asList(null, null));
+    assertThat(rowWithMissingHQ.get(VCFConstants.HAPLOTYPE_QUALITY_KEY))
+        .isEqualTo(Arrays.asList(null, null));
   }
 
   @Test


### PR DESCRIPTION
If the flag field is not presented in the VCF record, the `varaintContext.hasAttribute()` will return false, but we still need to set the flag field value as `false`. I added an "else if" to check if the type is `Flag` and then set the field value is `false'.

Also in the test part, changed some String field names to field names in `VCFConstants` to be identical to the main implementation.