### PR TITLE
BQ sink

### DIFF
--- a/src/main/java/com/google/gcp_variant_transforms/beam/VcfToBqPipelineRunner.java
+++ b/src/main/java/com/google/gcp_variant_transforms/beam/VcfToBqPipelineRunner.java
@@ -67,11 +67,11 @@ public final class VcfToBqPipelineRunner implements PipelineRunner {
 
     PCollection<TableRow> validRowCollection = tableRowTuple.get(VALID_VARIANT_TO_BQ_RECORD_TAG);
 
-//    validRowCollection.apply("WriteTableRowToBigQuery",
-//        BigQueryIO.writeTableRows().to(context.getOutput())
-//            .withSchema(context.getBqSchema())
-//            .withWriteDisposition(BigQueryIO.Write.WriteDisposition.WRITE_APPEND)
-//            .withCreateDisposition(BigQueryIO.Write.CreateDisposition.CREATE_IF_NEEDED));
+    validRowCollection.apply("WriteTableRowToBigQuery",
+        BigQueryIO.writeTableRows().to(context.getOutput())
+            .withSchema(context.getBqSchema())
+            .withWriteDisposition(BigQueryIO.Write.WriteDisposition.WRITE_APPEND)
+            .withCreateDisposition(BigQueryIO.Write.CreateDisposition.CREATE_IF_NEEDED));
 
     PCollection<MalformedRecord> errorMessageCollection =
         tableRowTuple.get(MALFORMED_RECORD_ERROR_MESSAGE_TAG);

--- a/src/main/java/com/google/gcp_variant_transforms/beam/VcfToBqPipelineRunner.java
+++ b/src/main/java/com/google/gcp_variant_transforms/beam/VcfToBqPipelineRunner.java
@@ -82,8 +82,8 @@ public final class VcfToBqPipelineRunner implements PipelineRunner {
             record.getReferenceBases(), record.getErrorMessage())))
         .apply(FileIO.<List<String>>write()
             .via(new MalformedRecordCSVSink(Arrays.asList(Constants.ColumnKeyNames.REFERENCE_NAME,
-                Constants.ColumnKeyNames.START_POSITION, Constants.ColumnKeyNames.REFERENCE_BASES
-                , "error_message")))
+                Constants.ColumnKeyNames.START_POSITION, Constants.ColumnKeyNames.REFERENCE_BASES,
+                "error_message")))
             .to(context.getMalformedRecordsMessagePath())
             .withPrefix("malformed_record")
             .withSuffix(".csv"));

--- a/src/main/java/com/google/gcp_variant_transforms/beam/VcfToBqPipelineRunner.java
+++ b/src/main/java/com/google/gcp_variant_transforms/beam/VcfToBqPipelineRunner.java
@@ -58,14 +58,15 @@ public final class VcfToBqPipelineRunner implements PipelineRunner {
                     TupleTagList.of(MALFORMED_RECORD_ERROR_MESSAGE_TAG)));
 
     PCollection<TableRow> validRowCollection = tableRowTuple.get(VALID_VARIANT_TO_BQ_RECORD_TAG);
-    PCollection<String> errorMessageCollection =
-        tableRowTuple.get(MALFORMED_RECORD_ERROR_MESSAGE_TAG);
 
     validRowCollection.apply("WriteTableRowToBigQuery",
         BigQueryIO.writeTableRows().to(context.getOutput())
             .withSchema(context.getBqSchema())
             .withWriteDisposition(BigQueryIO.Write.WriteDisposition.WRITE_APPEND)
             .withCreateDisposition(BigQueryIO.Write.CreateDisposition.CREATE_IF_NEEDED));
+
+    PCollection<String> errorMessageCollection =
+        tableRowTuple.get(MALFORMED_RECORD_ERROR_MESSAGE_TAG);
 
     errorMessageCollection
         .apply(TextIO.write().to(context.getMalformedRecordsMessagePath()).withNoSpilling());

--- a/src/main/java/com/google/gcp_variant_transforms/beam/VcfToBqPipelineRunner.java
+++ b/src/main/java/com/google/gcp_variant_transforms/beam/VcfToBqPipelineRunner.java
@@ -4,23 +4,31 @@ package com.google.gcp_variant_transforms.beam;
 
 import com.google.api.services.bigquery.model.TableRow;
 import com.google.gcp_variant_transforms.beam.helper.ConvertVariantToRowFn;
+import com.google.gcp_variant_transforms.common.Constants;
+import com.google.gcp_variant_transforms.entity.MalformedRecord;
 import com.google.gcp_variant_transforms.library.BigQueryRowGenerator;
+import com.google.gcp_variant_transforms.library.MalformedRecordCSVSink;
 import com.google.inject.Inject;
 import com.google.gcp_variant_transforms.beam.helper.ConvertLineToVariantFn;
 import com.google.gcp_variant_transforms.library.VcfParser;
 import com.google.gcp_variant_transforms.options.VcfToBqContext;
 import com.google.gcp_variant_transforms.options.VcfToBqOptions;
 import htsjdk.variant.variantcontext.VariantContext;
+import org.apache.beam.sdk.io.FileIO;
 import org.apache.beam.sdk.io.TextIO;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.transforms.Filter;
+import org.apache.beam.sdk.transforms.MapElements;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionTuple;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.TupleTagList;
+import org.apache.beam.sdk.values.TypeDescriptors;
+import java.util.Arrays;
+import java.util.List;
 
 public final class VcfToBqPipelineRunner implements PipelineRunner {
 
@@ -30,7 +38,7 @@ public final class VcfToBqPipelineRunner implements PipelineRunner {
   private final BigQueryRowGenerator bigQueryRowGenerator;
 
   private final TupleTag<TableRow> VALID_VARIANT_TO_BQ_RECORD_TAG = new TupleTag<>() {};
-  private final TupleTag<String> MALFORMED_RECORD_ERROR_MESSAGE_TAG = new TupleTag<>() {};
+  private final TupleTag<MalformedRecord> MALFORMED_RECORD_ERROR_MESSAGE_TAG = new TupleTag<>() {};
 
   /** Implementation of {@link PipelineRunner} service. */
   @Inject
@@ -59,17 +67,26 @@ public final class VcfToBqPipelineRunner implements PipelineRunner {
 
     PCollection<TableRow> validRowCollection = tableRowTuple.get(VALID_VARIANT_TO_BQ_RECORD_TAG);
 
-    validRowCollection.apply("WriteTableRowToBigQuery",
-        BigQueryIO.writeTableRows().to(context.getOutput())
-            .withSchema(context.getBqSchema())
-            .withWriteDisposition(BigQueryIO.Write.WriteDisposition.WRITE_APPEND)
-            .withCreateDisposition(BigQueryIO.Write.CreateDisposition.CREATE_IF_NEEDED));
+//    validRowCollection.apply("WriteTableRowToBigQuery",
+//        BigQueryIO.writeTableRows().to(context.getOutput())
+//            .withSchema(context.getBqSchema())
+//            .withWriteDisposition(BigQueryIO.Write.WriteDisposition.WRITE_APPEND)
+//            .withCreateDisposition(BigQueryIO.Write.CreateDisposition.CREATE_IF_NEEDED));
 
-    PCollection<String> errorMessageCollection =
+    PCollection<MalformedRecord> errorMessageCollection =
         tableRowTuple.get(MALFORMED_RECORD_ERROR_MESSAGE_TAG);
 
-    errorMessageCollection
-        .apply(TextIO.write().to(context.getMalformedRecordsMessagePath()).withNoSpilling());
+    errorMessageCollection.apply(MapElements
+        .into(TypeDescriptors.lists(TypeDescriptors.strings()))
+        .via(record -> Arrays.asList(record.getReferenceName(), record.getStart(),
+            record.getReferenceBases(), record.getErrorMessage())))
+        .apply(FileIO.<List<String>>write()
+            .via(new MalformedRecordCSVSink(Arrays.asList(Constants.ColumnKeyNames.REFERENCE_NAME,
+                Constants.ColumnKeyNames.START_POSITION, Constants.ColumnKeyNames.REFERENCE_BASES
+                , "error_message")))
+            .to(context.getMalformedRecordsMessagePath())
+            .withPrefix("malformed_record")
+            .withSuffix(".csv"));
 
     pipeline.run().waitUntilFinish();
   }

--- a/src/main/java/com/google/gcp_variant_transforms/beam/helper/ConvertVariantToRowFn.java
+++ b/src/main/java/com/google/gcp_variant_transforms/beam/helper/ConvertVariantToRowFn.java
@@ -38,11 +38,12 @@ public class ConvertVariantToRowFn extends DoFn<VariantContext, TableRow> {
           .output(bigQueryRowGenerator.convertToBQRow(variantContext, vcfHeader));
     } catch (Exception e) {
       if (allowMalformedRecords && e instanceof MalformedRecordException) {
-        MalformedRecordException malformedRecordException = (MalformedRecordException) e;
+        MalformedRecordException malformedRecordException = (MalformedRecordException)e;
         receiver.get(errorMessages).output(
             new MalformedRecord(malformedRecordException.getReferenceName(),
-                malformedRecordException.getStart(), malformedRecordException.getReferenceBases()
-                , malformedRecordException.getMessage()));
+                    malformedRecordException.getStart(),
+                    malformedRecordException.getReferenceBases(),
+                    malformedRecordException.getMessage()));
       } else {
         throw new RuntimeException(e.getMessage());
       }

--- a/src/main/java/com/google/gcp_variant_transforms/beam/helper/ConvertVariantToRowFn.java
+++ b/src/main/java/com/google/gcp_variant_transforms/beam/helper/ConvertVariantToRowFn.java
@@ -3,6 +3,8 @@
 package com.google.gcp_variant_transforms.beam.helper;
 
 import com.google.api.services.bigquery.model.TableRow;
+import com.google.gcp_variant_transforms.entity.MalformedRecord;
+import com.google.gcp_variant_transforms.exceptions.MalformedRecordException;
 import com.google.gcp_variant_transforms.library.BigQueryRowGenerator;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.vcf.VCFHeader;
@@ -16,11 +18,11 @@ public class ConvertVariantToRowFn extends DoFn<VariantContext, TableRow> {
   private final BigQueryRowGenerator bigQueryRowGenerator;
   private final VCFHeader vcfHeader;
   private final TupleTag<TableRow> validRecords;
-  private final TupleTag<String> errorMessages;
+  private final TupleTag<MalformedRecord> errorMessages;
 
   public ConvertVariantToRowFn(BigQueryRowGenerator bigQueryRowGenerator, VCFHeader vcfHeader,
                                boolean allowMalformedRecords, TupleTag<TableRow> validRecords,
-                               TupleTag<String> errorMessages) {
+                               TupleTag<MalformedRecord> errorMessages) {
     this.bigQueryRowGenerator = bigQueryRowGenerator;
     this.vcfHeader = vcfHeader;
     this.allowMalformedRecords = allowMalformedRecords;
@@ -35,8 +37,12 @@ public class ConvertVariantToRowFn extends DoFn<VariantContext, TableRow> {
       receiver.get(validRecords)
           .output(bigQueryRowGenerator.convertToBQRow(variantContext, vcfHeader));
     } catch (Exception e) {
-      if (allowMalformedRecords) {
-        receiver.get(errorMessages).output(e.getMessage());
+      if (allowMalformedRecords && e instanceof MalformedRecordException) {
+        MalformedRecordException malformedRecordException = (MalformedRecordException) e;
+        receiver.get(errorMessages).output(
+            new MalformedRecord(malformedRecordException.getReferenceName(),
+                malformedRecordException.getStart(), malformedRecordException.getReferenceBases()
+                , malformedRecordException.getMessage()));
       } else {
         throw new RuntimeException(e.getMessage());
       }

--- a/src/main/java/com/google/gcp_variant_transforms/common/Constants.java
+++ b/src/main/java/com/google/gcp_variant_transforms/common/Constants.java
@@ -8,7 +8,7 @@ package com.google.gcp_variant_transforms.common;
 public class Constants {
     public static final String DEFAULT_PHASESET = "*";
     public static final int MISSING_GENOTYPE_VALUE = -1;
-    public static final int DEFAULT_FIELD_COUNT = -1;
+    public static final int DEFAULT_REPEATED_FIELD_COUNT = -1;
 
     /**
      * Column filed name constants in the BigQuery schema.

--- a/src/main/java/com/google/gcp_variant_transforms/entity/MalformedRecord.java
+++ b/src/main/java/com/google/gcp_variant_transforms/entity/MalformedRecord.java
@@ -1,0 +1,40 @@
+// Copyright 2020 Google LLC
+
+package com.google.gcp_variant_transforms.entity;
+
+import java.io.Serializable;
+
+/**
+ * Malformed VCF record, it should include the contig, start position, reference bases and error
+ * message.
+ */
+public class MalformedRecord implements Serializable {
+  private final String referenceName;
+  private final String errorMessage;
+  private final String referenceBases;
+  private final String start;
+
+  public MalformedRecord(String referenceName, String start, String referenceBases,
+                         String errorMessage) {
+    this.referenceName = referenceName;
+    this.start = start;
+    this.referenceBases = referenceBases;
+    this.errorMessage = errorMessage;
+  }
+
+  public String getReferenceName() {
+    return referenceName;
+  }
+
+  public String getErrorMessage() {
+    return errorMessage;
+  }
+
+  public String getReferenceBases() {
+    return referenceBases;
+  }
+
+  public String getStart() {
+    return start;
+  }
+}

--- a/src/main/java/com/google/gcp_variant_transforms/exceptions/MalformedRecordException.java
+++ b/src/main/java/com/google/gcp_variant_transforms/exceptions/MalformedRecordException.java
@@ -1,0 +1,49 @@
+// Copyright 2020 Google LLC
+
+package com.google.gcp_variant_transforms.exceptions;
+
+/**
+ * Runtime Exception of malformed records. It contains the basic information of the record and
+ * error message.
+ */
+public class MalformedRecordException extends RuntimeException {
+  private final String referenceName;
+  private final String start;
+  private final String referenceBases;
+
+  public MalformedRecordException(String message, String referenceName, String start,
+                                  String referenceBases) {
+    super(message);
+    this.referenceName = referenceName;
+    this.start = start;
+    this.referenceBases = referenceBases;
+  }
+
+  public MalformedRecordException(String message, Throwable cause, String referenceName,
+                                  String start, String referenceBases) {
+    super(message, cause);
+    this.referenceName = referenceName;
+    this.start = start;
+    this.referenceBases = referenceBases;
+  }
+
+  public MalformedRecordException(Throwable cause, String referenceName, String start,
+                                  String referenceBases) {
+    super(cause);
+    this.referenceName = referenceName;
+    this.start = start;
+    this.referenceBases = referenceBases;
+  }
+
+  public String getReferenceName() {
+    return referenceName;
+  }
+
+  public String getStart() {
+    return start;
+  }
+
+  public String getReferenceBases() {
+    return referenceBases;
+  }
+}

--- a/src/main/java/com/google/gcp_variant_transforms/library/BigQueryRowGeneratorImpl.java
+++ b/src/main/java/com/google/gcp_variant_transforms/library/BigQueryRowGeneratorImpl.java
@@ -25,7 +25,7 @@ public class BigQueryRowGeneratorImpl implements BigQueryRowGenerator, Serializa
     TableRow row = new TableRow();
 
     row.set(Constants.ColumnKeyNames.REFERENCE_NAME, variantContext.getContig());
-    row.set(Constants.ColumnKeyNames.START_POSITION, variantContext.getStart() - 1);
+    row.set(Constants.ColumnKeyNames.START_POSITION, variantContext.getStart());
     row.set(Constants.ColumnKeyNames.END_POSITION, variantContext.getEnd());
 
     row.set(Constants.ColumnKeyNames.REFERENCE_BASES,

--- a/src/main/java/com/google/gcp_variant_transforms/library/BigQueryRowGeneratorImpl.java
+++ b/src/main/java/com/google/gcp_variant_transforms/library/BigQueryRowGeneratorImpl.java
@@ -24,27 +24,33 @@ public class BigQueryRowGeneratorImpl implements BigQueryRowGenerator, Serializa
     TableRow row = new TableRow();
 
     row.set(Constants.ColumnKeyNames.REFERENCE_NAME, variantContext.getContig());
-    row.set(Constants.ColumnKeyNames.START_POSITION, variantContext.getStart());
+    row.set(Constants.ColumnKeyNames.START_POSITION, variantContext.getStart() - 1);
     row.set(Constants.ColumnKeyNames.END_POSITION, variantContext.getEnd());
 
     row.set(Constants.ColumnKeyNames.REFERENCE_BASES,
-            variantToBqUtils.getReferenceBases(variantContext));
-    row.set(Constants.ColumnKeyNames.NAMES, variantToBqUtils.getNames(variantContext));
+        variantToBqUtils.getReferenceBases(variantContext));
+    try {
+      row.set(Constants.ColumnKeyNames.NAMES, variantToBqUtils.getNames(variantContext));
 
-    // Write alt field and info field to BQ row.
-    List<TableRow> altMetadata = variantToBqUtils.getAlternateBases(variantContext);
-    // AltMetadata should contain Info fields with Number='A' tag, then be added to the row.
-    // The rest of Info fields will be directly added to the base BQ row.
-    variantToBqUtils.addInfo(row, variantContext, altMetadata, vcfHeader, 2);
-    row.set(Constants.ColumnKeyNames.ALTERNATE_BASES, altMetadata);
+      // Write alt field and info field to BQ row.
+      List<TableRow> altMetadata = variantToBqUtils.getAlternateBases(variantContext);
+      // AltMetadata should contain Info fields with Number='A' tag, then be added to the row.
+      // The rest of Info fields will be directly added to the base BQ row.
+      variantToBqUtils.addInfo(row, variantContext, altMetadata, vcfHeader, 2);
+      row.set(Constants.ColumnKeyNames.ALTERNATE_BASES, altMetadata);
 
-    row.set(Constants.ColumnKeyNames.QUALITY, variantContext.getPhredScaledQual());
-    row.set(Constants.ColumnKeyNames.FILTER, variantToBqUtils.getFilters(variantContext));
+      row.set(Constants.ColumnKeyNames.QUALITY, variantContext.getPhredScaledQual());
+      row.set(Constants.ColumnKeyNames.FILTER, variantToBqUtils.getFilters(variantContext));
 
-    // Write calls to BQ row.
-    List<TableRow> callRows = variantToBqUtils.getCalls(variantContext, vcfHeader);
-    row.set(Constants.ColumnKeyNames.CALLS, callRows);
-
+      // Write calls to BQ row.
+      List<TableRow> callRows = variantToBqUtils.getCalls(variantContext, vcfHeader);
+      row.set(Constants.ColumnKeyNames.CALLS, callRows);
+    } catch (Exception e) {
+      String malformedRecordInfoPrefix = "Record with contig: " + variantContext.getContig() + "," +
+          " start position: " + variantContext.getStart() + ", reference bases: " +
+          variantToBqUtils.getReferenceBases(variantContext) + ", error: ";
+      throw new RuntimeException(malformedRecordInfoPrefix + e.getMessage());
+    }
     return row;
   }
 }

--- a/src/main/java/com/google/gcp_variant_transforms/library/BigQueryRowGeneratorImpl.java
+++ b/src/main/java/com/google/gcp_variant_transforms/library/BigQueryRowGeneratorImpl.java
@@ -4,6 +4,7 @@ package com.google.gcp_variant_transforms.library;
 
 import com.google.api.services.bigquery.model.TableRow;
 import com.google.gcp_variant_transforms.common.Constants;
+import com.google.gcp_variant_transforms.exceptions.MalformedRecordException;
 import com.google.inject.Inject;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.vcf.VCFHeader;
@@ -46,10 +47,9 @@ public class BigQueryRowGeneratorImpl implements BigQueryRowGenerator, Serializa
       List<TableRow> callRows = variantToBqUtils.getCalls(variantContext, vcfHeader);
       row.set(Constants.ColumnKeyNames.CALLS, callRows);
     } catch (Exception e) {
-      String malformedRecordInfoPrefix = "Record with contig: " + variantContext.getContig() + "," +
-          " start position: " + variantContext.getStart() + ", reference bases: " +
-          variantToBqUtils.getReferenceBases(variantContext) + ", error: ";
-      throw new RuntimeException(malformedRecordInfoPrefix + e.getMessage());
+      throw new MalformedRecordException(e.getMessage(), variantContext.getContig(),
+          String.valueOf(variantContext.getStart()),
+          variantToBqUtils.getReferenceBases(variantContext));
     }
     return row;
   }

--- a/src/main/java/com/google/gcp_variant_transforms/library/MalformedRecordCSVSink.java
+++ b/src/main/java/com/google/gcp_variant_transforms/library/MalformedRecordCSVSink.java
@@ -1,0 +1,36 @@
+// Copyright 2020 Google LLC
+
+package com.google.gcp_variant_transforms.library;
+
+import com.google.common.base.Joiner;
+import org.apache.beam.sdk.io.FileIO;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.channels.Channels;
+import java.nio.channels.WritableByteChannel;
+import java.util.List;
+
+/**
+ * CSV sink class, includes header of the CSV file and methods of opening and writing CSV records.
+ */
+public class MalformedRecordCSVSink implements FileIO.Sink<List<String>>{
+  private String header;
+  private PrintWriter writer;
+
+  public MalformedRecordCSVSink(List<String> colNames) {
+    this.header = Joiner.on(",").join(colNames);
+  }
+
+  public void open(WritableByteChannel channel) throws IOException {
+    writer = new PrintWriter(Channels.newOutputStream(channel));
+    writer.println(header);
+  }
+
+  public void write(List<String> element) throws IOException {
+    writer.println(Joiner.on(",").join(element));
+  }
+
+  public void flush() throws IOException {
+    writer.flush();
+  }
+}

--- a/src/main/java/com/google/gcp_variant_transforms/library/SchemaGeneratorImpl.java
+++ b/src/main/java/com/google/gcp_variant_transforms/library/SchemaGeneratorImpl.java
@@ -101,8 +101,8 @@ public class SchemaGeneratorImpl implements SchemaGenerator {
   @VisibleForTesting
   protected TableFieldSchema convertCompoundHeaderLineToField(VCFCompoundHeaderLine headerLine) {
     String bqFieldMode;
-    if (headerLine.getCountType() == VCFHeaderLineCount.INTEGER &&
-        headerLine.getCount() <= 1){
+    if ((headerLine.getCountType() == VCFHeaderLineCount.INTEGER &&
+        headerLine.getCount() <= 1) || (headerLine.getCountType() == VCFHeaderLineCount.A)) {
       bqFieldMode = SchemaUtils.BQFieldMode.NULLABLE;
     } else { bqFieldMode = SchemaUtils.BQFieldMode.REPEATED; }   // Number = A, R, G, or >1
     return new TableFieldSchema()

--- a/src/main/java/com/google/gcp_variant_transforms/library/SchemaGeneratorImpl.java
+++ b/src/main/java/com/google/gcp_variant_transforms/library/SchemaGeneratorImpl.java
@@ -19,7 +19,7 @@ import java.util.Collection;
  * Service to create BigQuery Schema from VCFHeader 
  */
 public class SchemaGeneratorImpl implements SchemaGenerator {
-  
+
   public TableSchema getSchema(VCFHeader vcfHeader) {
     ImmutableList<TableFieldSchema> schemaFields = getFields(vcfHeader);
     return new TableSchema().setFields(schemaFields);
@@ -44,9 +44,9 @@ public class SchemaGeneratorImpl implements SchemaGenerator {
     for (VCFInfoHeaderLine infoHeaderLine : vcfHeader.getInfoHeaderLines()){
       // INFO header lines with Number = 'A' are added under the alternate bases record
       if (infoHeaderLine.getCountType() != VCFHeaderLineCount.A)
-        fields.add(convertCompoundHeaderLineToField(infoHeaderLine));
+        fields.add(convertCompoundHeaderLineToField(infoHeaderLine, true));
     }
-    
+
     return fields.build();
   }
 
@@ -63,11 +63,11 @@ public class SchemaGeneratorImpl implements SchemaGenerator {
         fieldName.equals(Constants.ColumnKeyNames.CALLS)) {
       field = createRecordField(vcfHeader, fieldName);
     } else {
-        field = new TableFieldSchema()
-            .setName(fieldName)
-            .setDescription(SchemaUtils.constantFieldNameToDescriptionMap.get(fieldName))
-            .setMode(SchemaUtils.constantFieldNameToModeMap.get(fieldName))
-            .setType(SchemaUtils.constantFieldNameToTypeMap.get(fieldName));
+      field = new TableFieldSchema()
+          .setName(fieldName)
+          .setDescription(SchemaUtils.constantFieldNameToDescriptionMap.get(fieldName))
+          .setMode(SchemaUtils.constantFieldNameToModeMap.get(fieldName))
+          .setType(SchemaUtils.constantFieldNameToTypeMap.get(fieldName));
     }
     return field;
   }
@@ -99,10 +99,11 @@ public class SchemaGeneratorImpl implements SchemaGenerator {
    * @return an INFO or FORMAT Field
    */
   @VisibleForTesting
-  protected TableFieldSchema convertCompoundHeaderLineToField(VCFCompoundHeaderLine headerLine) {
+  protected TableFieldSchema convertCompoundHeaderLineToField(VCFCompoundHeaderLine headerLine,
+                                                              boolean isInfo) {
     String bqFieldMode;
-    if ((headerLine.getCountType() == VCFHeaderLineCount.INTEGER &&
-        headerLine.getCount() <= 1) || (headerLine.getCountType() == VCFHeaderLineCount.A)) {
+    if ((headerLine.getCountType() == VCFHeaderLineCount.INTEGER && headerLine.getCount() <= 1) ||
+        ((headerLine.getCountType() == VCFHeaderLineCount.A) && isInfo)) {
       bqFieldMode = SchemaUtils.BQFieldMode.NULLABLE;
     } else { bqFieldMode = SchemaUtils.BQFieldMode.REPEATED; }   // Number = A, R, G, or >1
     return new TableFieldSchema()
@@ -132,13 +133,13 @@ public class SchemaGeneratorImpl implements SchemaGenerator {
     }
     // Adds the FORMAT fields under the Calls record
     for (VCFFormatHeaderLine formatHeaderLine : vcfHeader.getFormatHeaderLines()){
-        // Phaseset and Genotype are already added to callSubFields
-        String callSubFieldName = formatHeaderLine.getID();
-        if (!callSubFieldName.equals(VCFConstants.GENOTYPE_KEY)
-            && !callSubFieldName.equals(VCFConstants.PHASE_SET_KEY)) {
-          callSubFields.add(convertCompoundHeaderLineToField(formatHeaderLine));
-        }
+      // Phaseset and Genotype are already added to callSubFields
+      String callSubFieldName = formatHeaderLine.getID();
+      if (!callSubFieldName.equals(VCFConstants.GENOTYPE_KEY)
+          && !callSubFieldName.equals(VCFConstants.PHASE_SET_KEY)) {
+        callSubFields.add(convertCompoundHeaderLineToField(formatHeaderLine, false));
       }
+    }
     return callSubFields.build();
   }
 
@@ -161,7 +162,7 @@ public class SchemaGeneratorImpl implements SchemaGenerator {
     // Adds the INFO fields with Number = A (i.e., one value for each alternate) among alternates.
     for (VCFInfoHeaderLine infoHeaderLine : vcfHeader.getInfoHeaderLines()){
       if (infoHeaderLine.getCountType() == VCFHeaderLineCount.A){
-        altSubFields.add(convertCompoundHeaderLineToField(infoHeaderLine));
+        altSubFields.add(convertCompoundHeaderLineToField(infoHeaderLine, true));
       }
     }
     return altSubFields.build();

--- a/src/main/java/com/google/gcp_variant_transforms/library/SchemaGeneratorImpl.java
+++ b/src/main/java/com/google/gcp_variant_transforms/library/SchemaGeneratorImpl.java
@@ -100,10 +100,10 @@ public class SchemaGeneratorImpl implements SchemaGenerator {
    */
   @VisibleForTesting
   protected TableFieldSchema convertCompoundHeaderLineToField(VCFCompoundHeaderLine headerLine,
-                                                              boolean isInfo) {
+                                                              boolean isMovedToAlt) {
     String bqFieldMode;
     if ((headerLine.getCountType() == VCFHeaderLineCount.INTEGER && headerLine.getCount() <= 1) ||
-        ((headerLine.getCountType() == VCFHeaderLineCount.A) && isInfo)) {
+        ((headerLine.getCountType() == VCFHeaderLineCount.A) && isMovedToAlt)) {
       bqFieldMode = SchemaUtils.BQFieldMode.NULLABLE;
     } else { bqFieldMode = SchemaUtils.BQFieldMode.REPEATED; }   // Number = A, R, G, or >1
     return new TableFieldSchema()

--- a/src/main/java/com/google/gcp_variant_transforms/library/VariantToBqUtils.java
+++ b/src/main/java/com/google/gcp_variant_transforms/library/VariantToBqUtils.java
@@ -24,8 +24,8 @@ public interface VariantToBqUtils {
 
   /**
    * Get names from VariantContext's ID field. It should be a semi-colon separated list of
-   * unique identifiers where available. In each separated ID, set null in this field if there is
-   * a missing value.
+   * unique identifiers where available.
+   * As names field is repeated, if the value is a missing value("."), return an empty list.
    * @param variantContext
    * @return List of names after handling missing value.
    */
@@ -39,7 +39,9 @@ public interface VariantToBqUtils {
   public List<TableRow> getAlternateBases(VariantContext variantContext);
 
   /**
-   * Get filter set. If it is an empty set, it is required to add "PASS" in the filter.
+   * Get filter set. If it is an empty set in {@link VariantContext}, it means the current filter
+   * status is "PASS", and we need to add "PASS" in the filter row field.
+   * If the filter value is missing value("."), return null.
    * @param variantContext
    * @return Filter set after handling "PASS" and missing value.
    */
@@ -47,9 +49,11 @@ public interface VariantToBqUtils {
 
   /**
    * <p>
-   *  Add variant Info field into BQ table row. For each field in the VCFHeader, check if the
+   *  Add variant Info field into BQ table row. Iterate each field in the VCFHeader, check if the
    *  field is presented. If the field type is `Flag` but not presented, it will set `false` in
-   *  the row field.
+   *  the corresponding row field. And the row field name should match the schema format. If the
+   *  attribute name does not match the schema format, we will get the sanitized field name and
+   *  set the row value in the sanitized field.
    * </p>
    *
    * <p>
@@ -112,8 +116,13 @@ public interface VariantToBqUtils {
   public void addGenotypes(TableRow row, List<Allele> alleles, VariantContext variantContext);
 
   /**
-   * Add all format attribute fields in {@link Genotype}, if there is phase set field(PS), set
-   * phase set. If there is no such phase set field, set default phase set "*".
+   * Add all format attribute fields in {@link Genotype}. Iterate each format field in VCFHeader,
+   * if the field is present and it is not the genotype field, get the value and set in the
+   * corresponding call field. Note that if the field name does not match the schema format, we
+   * will get the sanitized field name and set the row value in the sanitized field.
+   *
+   * if there is phase set field(PS), set phase set. If there is no such phase set field, set
+   * default phase set "*".
    * @param row TableRow for each call(sample).
    * @param genotype Current genotype sample in the VariantContext
    * @param vcfHeader Define the field type and count format.

--- a/src/main/java/com/google/gcp_variant_transforms/library/VariantToBqUtils.java
+++ b/src/main/java/com/google/gcp_variant_transforms/library/VariantToBqUtils.java
@@ -127,7 +127,7 @@ public interface VariantToBqUtils {
    * @param genotype Current genotype sample in the VariantContext
    * @param vcfHeader Define the field type and count format.
    */
-  public void addFormatAndPhaseSet(TableRow row, Genotype genotype, VCFHeader vcfHeader);
+  public void addFormat(TableRow row, Genotype genotype, VCFHeader vcfHeader);
 
   /**
    * <p>

--- a/src/main/java/com/google/gcp_variant_transforms/library/VariantToBqUtilsImpl.java
+++ b/src/main/java/com/google/gcp_variant_transforms/library/VariantToBqUtilsImpl.java
@@ -140,10 +140,11 @@ public class VariantToBqUtilsImpl implements VariantToBqUtils, Serializable {
         return convertSingleObjectToDefinedType(value, type);
       }
     } else {
-      // Deal with list of values. If the current value is single value with default repeated
-      // field count, store the value to a list.
+      // Deal with repeated values. If the current value is single value with default repeated
+      // field count, check if the string value need to split with comma, and store the value to a
+      // list.
       List<Object> valueList = value instanceof List ?
-          (List<Object>)value : Collections.singletonList(value);
+          (List<Object>)value : Arrays.asList(((String)value).split(","));
       if (count != Constants.DEFAULT_REPEATED_FIELD_COUNT && count != valueList.size()) {
         throw new CountNotMatchException("Value \"" + value + "\" size does not match the count " +
             "defined by VCFHeader");

--- a/src/main/java/com/google/gcp_variant_transforms/library/VariantToBqUtilsImpl.java
+++ b/src/main/java/com/google/gcp_variant_transforms/library/VariantToBqUtilsImpl.java
@@ -16,11 +16,7 @@ import htsjdk.variant.vcf.VCFHeaderLineCount;
 import htsjdk.variant.vcf.VCFHeaderLineType;
 import htsjdk.variant.vcf.VCFInfoHeaderLine;
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 /**
  * Implementation class for {@link VariantToBqUtils}. It provides functionalities to set default
@@ -121,7 +117,7 @@ public class VariantToBqUtilsImpl implements VariantToBqUtils, Serializable {
 
   public Object convertToDefinedType(Object value, VCFHeaderLineType type, int count) {
     if (!(value instanceof List || count == Constants.DEFAULT_REPEATED_FIELD_COUNT)) {
-      // Deal with single value.
+      // Deal with single string value and handle string value with comma.
       if ((value instanceof String) && ((String)value).contains(",")) {
         // Split string value.
         String valueStr = (String)value;
@@ -134,8 +130,10 @@ public class VariantToBqUtilsImpl implements VariantToBqUtils, Serializable {
         return convertSingleObjectToDefinedType(value, type);
       }
     } else {
-      // Deal with list of values.
-      List<Object> valueList = (List<Object>)value;
+      // Deal with list of values. If the current value is single value with default repeated
+      // field count, store the value to a list.
+      List<Object> valueList = value instanceof List ?
+          (List<Object>)value : Collections.singletonList(value);
       if (count != Constants.DEFAULT_REPEATED_FIELD_COUNT && count != valueList.size()) {
         throw new CountNotMatchException("Value \"" + value + "\" size does not match the count " +
             "defined by VCFHeader");

--- a/src/test/java/com/google/gcp_variant_transforms/library/BigQueryRowGeneratorTest.java
+++ b/src/test/java/com/google/gcp_variant_transforms/library/BigQueryRowGeneratorTest.java
@@ -141,14 +141,14 @@ public class BigQueryRowGeneratorTest {
     assertThat(rowWithMissingHQ.get(Constants.ColumnKeyNames.CALLS_GENOTYPE))
         .isEqualTo(Arrays.asList(TEST_GENOTYPE, TEST_GENOTYPE));
     assertThat(rowWithMissingHQ.get(VCFConstants.HAPLOTYPE_QUALITY_KEY))
-        .isEqualTo(Arrays.asList(null, null));
+        .isEqualTo(Collections.emptyList());
   }
 
   @Test
   public void testBigQueryRowWithEmptyFields_whenCheckingRowElements_thenTrue() {
     // ID field is ".", which should be null in the BQ row.
     assertThat(rowWithEmptyFields.get(Constants.ColumnKeyNames.NAMES))
-        .isEqualTo(Collections.singletonList(null));
+        .isEqualTo(Collections.emptyList());
 
     // Quality field is ".", which should be -10 in the BQ row.
     assertThat(rowWithEmptyFields.get(Constants.ColumnKeyNames.QUALITY))

--- a/src/test/java/com/google/gcp_variant_transforms/library/BigQueryRowGeneratorTest.java
+++ b/src/test/java/com/google/gcp_variant_transforms/library/BigQueryRowGeneratorTest.java
@@ -34,7 +34,7 @@ import org.junit.Test;
  * 'getRows' method in ConvertVariantRowFn.java and BigQueryRowGeneratorImpl.java
  */
 public class BigQueryRowGeneratorTest {
-  private static final String TEST_FILE = "/usr/local/google/home/zqsun/project/test_platinum.vcf";
+  private static final String TEST_FILE = "src/test/resources/vcf_files_small_valid-4.0.vcf";
   private static final String TEST_REFERENCE_NAME = "20";
   private static final String TEST_ID= "rs6054257";
   private static final String TEST_REFERENCE_BASES = "G";

--- a/src/test/java/com/google/gcp_variant_transforms/library/BigQueryRowGeneratorTest.java
+++ b/src/test/java/com/google/gcp_variant_transforms/library/BigQueryRowGeneratorTest.java
@@ -34,7 +34,7 @@ import org.junit.Test;
  * 'getRows' method in ConvertVariantRowFn.java and BigQueryRowGeneratorImpl.java
  */
 public class BigQueryRowGeneratorTest {
-  private static final String TEST_FILE = "src/test/resources/vcf_files_small_valid-4.0.vcf";
+  private static final String TEST_FILE = "/usr/local/google/home/zqsun/project/test_platinum.vcf";
   private static final String TEST_REFERENCE_NAME = "20";
   private static final String TEST_ID= "rs6054257";
   private static final String TEST_REFERENCE_BASES = "G";

--- a/src/test/java/com/google/gcp_variant_transforms/library/LibraryTestModule.java
+++ b/src/test/java/com/google/gcp_variant_transforms/library/LibraryTestModule.java
@@ -11,6 +11,7 @@ public class LibraryTestModule extends AbstractModule {
   protected void configure() {
     bind(VcfParser.class).to(VcfParserImpl.class);
     bind(BigQueryRowGenerator.class).to(BigQueryRowGeneratorImpl.class);
+    bind(SchemaGenerator.class).to(SchemaGeneratorImpl.class);
     bind(VariantToBqUtils.class).to(VariantToBqUtilsImpl.class);
   }
 }

--- a/src/test/java/com/google/gcp_variant_transforms/library/SchemaGeneratorImplTest.java
+++ b/src/test/java/com/google/gcp_variant_transforms/library/SchemaGeneratorImplTest.java
@@ -411,7 +411,7 @@ public class SchemaGeneratorImplTest {
     // ID="AF" -- Genotype
     assertThat(alleleFrequency.getName()).isEqualTo(alleleFrequencyName);
     assertThat(alleleFrequency.getDescription()).isEqualTo(alleleFrequencyDescription);
-    assertThat(alleleFrequency.getMode()).isEqualTo(SchemaUtils.BQFieldMode.REPEATED);
+    assertThat(alleleFrequency.getMode()).isEqualTo(SchemaUtils.BQFieldMode.NULLABLE);
     assertThat(alleleFrequency.getType()).isEqualTo(SchemaUtils.BQFieldType.FLOAT);
   }
 

--- a/src/test/java/com/google/gcp_variant_transforms/library/SchemaGeneratorImplTest.java
+++ b/src/test/java/com/google/gcp_variant_transforms/library/SchemaGeneratorImplTest.java
@@ -38,7 +38,7 @@ public class SchemaGeneratorImplTest {
 
   @Inject public SchemaGeneratorImpl schemaGen;
   @Rule public final GuiceBerryRule guiceBerry = new GuiceBerryRule(TestEnv.class);
-  
+
   @Before
   public void constructMockVCFHeader(){
     mockedVcfHeader = mock(VCFHeader.class);
@@ -270,7 +270,7 @@ public class SchemaGeneratorImplTest {
     ImmutableList<TableFieldSchema> callFields = schemaGen.getCallSubFields(mockedVcfHeader);
     TableFieldSchema callsGenotypeField = callFields
         .get(SchemaUtils.FieldIndex.CALLS_GENOTYPE);
-    
+
     assertThat(callsGenotypeField.getName())
         .isEqualTo(Constants.ColumnKeyNames.CALLS_GENOTYPE);
     assertThat(callsGenotypeField.getDescription())
@@ -305,7 +305,8 @@ public class SchemaGeneratorImplTest {
     VCFInfoHeaderLine sampleInfoHeaderLine = new VCFInfoHeaderLine(name, count,
         infoType, description);
 
-    TableFieldSchema infoField = schemaGen.convertCompoundHeaderLineToField(sampleInfoHeaderLine);
+    TableFieldSchema infoField = schemaGen.convertCompoundHeaderLineToField(sampleInfoHeaderLine,
+        true);
 
     assertThat(infoField.getName()).isEqualTo(name);
     assertThat(infoField.getDescription()).isEqualTo(description);
@@ -417,16 +418,17 @@ public class SchemaGeneratorImplTest {
 
   @Test
   public void testConvertCompoundHeaderLineToField_whenFlag_thenIsEqualTo() {
-     String name = "sampleName";
-      String description = "sampleDescription";
-      VCFInfoHeaderLine infoHeaderLine = new VCFInfoHeaderLine(
-          name, 0, VCFHeaderLineType.Flag, description); // Number = 0
-      TableFieldSchema infoField = schemaGen.convertCompoundHeaderLineToField(infoHeaderLine);
+    String name = "sampleName";
+    String description = "sampleDescription";
+    VCFInfoHeaderLine infoHeaderLine = new VCFInfoHeaderLine(
+        name, 0, VCFHeaderLineType.Flag, description); // Number = 0
+    TableFieldSchema infoField = schemaGen.convertCompoundHeaderLineToField(infoHeaderLine,
+        true);
 
-      assertThat(infoField.getName()).isEqualTo(name);
-      assertThat(infoField.getDescription()).isEqualTo(description);
-      assertThat(infoField.getMode()).isEqualTo(SchemaUtils.BQFieldMode.NULLABLE);
-      assertThat(infoField.getType()).isEqualTo(SchemaUtils.BQFieldType.BOOLEAN);
+    assertThat(infoField.getName()).isEqualTo(name);
+    assertThat(infoField.getDescription()).isEqualTo(description);
+    assertThat(infoField.getMode()).isEqualTo(SchemaUtils.BQFieldMode.NULLABLE);
+    assertThat(infoField.getType()).isEqualTo(SchemaUtils.BQFieldType.BOOLEAN);
   }
 
   @Test
@@ -435,7 +437,8 @@ public class SchemaGeneratorImplTest {
     String description = "sampleDescription";
     VCFInfoHeaderLine infoHeaderLine = new VCFInfoHeaderLine(
         name, 2, VCFHeaderLineType.Integer, description); // Number > 1
-    TableFieldSchema infoField = schemaGen.convertCompoundHeaderLineToField(infoHeaderLine);
+    TableFieldSchema infoField = schemaGen.convertCompoundHeaderLineToField(infoHeaderLine,
+        false);
 
     assertThat(infoField.getName()).isEqualTo(name);
     assertThat(infoField.getDescription()).isEqualTo(description);
@@ -449,7 +452,7 @@ public class SchemaGeneratorImplTest {
     String description = "sampleDescription";
     VCFInfoHeaderLine infoHeaderLine = new VCFInfoHeaderLine(
         name, 1, VCFHeaderLineType.Integer, description); // Number = 1
-    TableFieldSchema infoField = schemaGen.convertCompoundHeaderLineToField(infoHeaderLine);
+    TableFieldSchema infoField = schemaGen.convertCompoundHeaderLineToField(infoHeaderLine, false);
 
     assertThat(infoField.getName()).isEqualTo(name);
     assertThat(infoField.getDescription()).isEqualTo(description);

--- a/src/test/java/com/google/gcp_variant_transforms/library/VariantToBqUtilsTest.java
+++ b/src/test/java/com/google/gcp_variant_transforms/library/VariantToBqUtilsTest.java
@@ -168,7 +168,6 @@ public class VariantToBqUtilsTest {
     when(variantContext.getGenotypes()).thenReturn(genotypesContext);
   }
 
-
   @Test
   public void testConvertStringValueToRightValueType_whenComparingElement_thenTrue() {
     // Test list of values.
@@ -243,7 +242,7 @@ public class VariantToBqUtilsTest {
     // Test empty fields.
     when(variantContext.getID()).thenReturn(VCFConstants.MISSING_VALUE_v4);
     assertThat(variantToBqUtils.getNames(variantContext))
-        .isEqualTo(Collections.singletonList(null));
+        .isEqualTo(Collections.emptyList());
   }
 
   @Test
@@ -331,7 +330,7 @@ public class VariantToBqUtilsTest {
    * GT:DP:PS:HQ    1|2:1:0:23,27
    * GT:DP:HQ         .:1:.,.
    * In the second record, genotypes will set [-1,-1] and phase set will set "*",
-   * and HQ will be [null, null]
+   * and HQ will be an empty list for repeated field.
    */
   @Test
   public void testAddCallsWithFieldValue_whenCheckingGenotypeElements_thenTrue() {
@@ -373,6 +372,6 @@ public class VariantToBqUtilsTest {
     assertThat(rowWithEmptyFields.get(Constants.ColumnKeyNames.CALLS_PHASESET))
         .isEqualTo(Constants.DEFAULT_PHASESET);
     assertThat(rowWithEmptyFields.get(VCFConstants.HAPLOTYPE_QUALITY_KEY))
-        .isEqualTo(Arrays.asList(null,null));
+        .isEqualTo(Collections.emptyList());
   }
 }


### PR DESCRIPTION
### Update
- Pipeline runner: get the BQ sink output
- repeated fields: for list value, check if there is missing value(".") and then return an empty list.
- sanitized fields: set the sanitized field for INFO and FORMAT fields.
- Schema: If count = 'A', the field mode should be `NULLABLE`

### Test
`./gradlew test`
**E2E Test** 
```
GOOGLE_CLOUD_PROJECT=tural-test-runner
RUNNER=DataflowRunner
INPUT_FILE=gs://tural-test-runner/vcf_files/plat001/platinum_genomes_deepvariant_vcf_NA12878_S1.vcf
JOB_NAME=java-test-run
GOOGLE_CLOUD_REGION=us-central1
TEMP_LOCATION=gs://${GOOGLE_CLOUD_PROJECT}/javawork/temp
OUTPUT=tural-test-runner:zqsun_bq_to_vcf_integration_tests.platinum_genomes_deepvariant_vcf_NA12878_S1
ALLOW_MALFORMED_RECORDS=true
MALFORMED_RECORDS_REPORT_PATH=../output/error_message

./gradlew vcfToBq -Prargs=" \
  --project=${GOOGLE_CLOUD_PROJECT} \
  --runner=${RUNNER} \
  --jobName=${JOB_NAME} \
  --region=${GOOGLE_CLOUD_REGION} \
  --tempLocation=${TEMP_LOCATION} \
  --inputFile=${INPUT_FILE} \
  --output=${OUTPUT} \
  --allowMalformedRecords=${ALLOW_MALFORMED_RECORDS} \
  --malformedRecordsReportPath=${MALFORMED_RECORDS_REPORT_PATH}"
```