### PR TITLE
Add use_1_based_coordiante flag

### DIFF
--- a/src/main/java/com/google/gcp_variant_transforms/beam/VcfToBqPipelineRunner.java
+++ b/src/main/java/com/google/gcp_variant_transforms/beam/VcfToBqPipelineRunner.java
@@ -54,7 +54,8 @@ public final class VcfToBqPipelineRunner implements PipelineRunner {
         .apply("VariantContextToBQRow",
             ParDo.of(new ConvertVariantToRowFn(bigQueryRowGenerator,
                 context.getVCFHeader(), context.getAllowMalformedRecords(),
-                    VALID_VARIANT_TO_BQ_RECORD_TAG, MALFORMED_RECORD_ERROR_MESSAGE_TAG))
+                    context.getUseOneBasedCoordinate(), VALID_VARIANT_TO_BQ_RECORD_TAG,
+                    MALFORMED_RECORD_ERROR_MESSAGE_TAG))
                 .withOutputTags(VALID_VARIANT_TO_BQ_RECORD_TAG,
                     TupleTagList.of(MALFORMED_RECORD_ERROR_MESSAGE_TAG)));
 

--- a/src/main/java/com/google/gcp_variant_transforms/beam/helper/ConvertVariantToRowFn.java
+++ b/src/main/java/com/google/gcp_variant_transforms/beam/helper/ConvertVariantToRowFn.java
@@ -13,17 +13,19 @@ import org.apache.beam.sdk.values.TupleTag;
 public class ConvertVariantToRowFn extends DoFn<VariantContext, TableRow> {
 
   private final boolean allowMalformedRecords;
+  private final boolean useOneBasedCoordinate;
   private final BigQueryRowGenerator bigQueryRowGenerator;
   private final VCFHeader vcfHeader;
   private final TupleTag<TableRow> validRecords;
   private final TupleTag<String> errorMessages;
 
   public ConvertVariantToRowFn(BigQueryRowGenerator bigQueryRowGenerator, VCFHeader vcfHeader,
-                               boolean allowMalformedRecords, TupleTag<TableRow> validRecords,
-                               TupleTag<String> errorMessages) {
+                               boolean allowMalformedRecords, boolean useOneBasedCoordinate,
+                               TupleTag<TableRow> validRecords, TupleTag<String> errorMessages) {
     this.bigQueryRowGenerator = bigQueryRowGenerator;
     this.vcfHeader = vcfHeader;
     this.allowMalformedRecords = allowMalformedRecords;
+    this.useOneBasedCoordinate = useOneBasedCoordinate;
     this.validRecords = validRecords;
     this.errorMessages = errorMessages;
   }
@@ -33,7 +35,8 @@ public class ConvertVariantToRowFn extends DoFn<VariantContext, TableRow> {
                              MultiOutputReceiver receiver) {
     try {
       receiver.get(validRecords)
-          .output(bigQueryRowGenerator.convertToBQRow(variantContext, vcfHeader));
+          .output(bigQueryRowGenerator.convertToBQRow(variantContext, vcfHeader,
+              useOneBasedCoordinate));
     } catch (Exception e) {
       if (allowMalformedRecords) {
         receiver.get(errorMessages).output(e.getMessage());

--- a/src/main/java/com/google/gcp_variant_transforms/library/BigQueryRowGenerator.java
+++ b/src/main/java/com/google/gcp_variant_transforms/library/BigQueryRowGenerator.java
@@ -19,5 +19,6 @@ public interface BigQueryRowGenerator {
    * @param vcfHeader
    * @return TableRow with all field values of one VCF record.
    */
-  public TableRow convertToBQRow(VariantContext variantContext, VCFHeader vcfHeader);
+  public TableRow convertToBQRow(VariantContext variantContext, VCFHeader vcfHeader,
+                                 boolean useOneBasedCoordinate);
 }

--- a/src/main/java/com/google/gcp_variant_transforms/library/BigQueryRowGeneratorImpl.java
+++ b/src/main/java/com/google/gcp_variant_transforms/library/BigQueryRowGeneratorImpl.java
@@ -20,13 +20,15 @@ public class BigQueryRowGeneratorImpl implements BigQueryRowGenerator, Serializa
   @Inject
   VariantToBqUtils variantToBqUtils;
 
-  public TableRow convertToBQRow(VariantContext variantContext, VCFHeader vcfHeader) {
+  public TableRow convertToBQRow(VariantContext variantContext, VCFHeader vcfHeader,
+                                 boolean useOneBasedCoordinate) {
     TableRow row = new TableRow();
 
     row.set(Constants.ColumnKeyNames.REFERENCE_NAME, variantContext.getContig());
-    row.set(Constants.ColumnKeyNames.START_POSITION, variantContext.getStart());
-    row.set(Constants.ColumnKeyNames.END_POSITION, variantContext.getEnd());
-
+    row.set(Constants.ColumnKeyNames.START_POSITION, variantToBqUtils.getStart(variantContext,
+        useOneBasedCoordinate));
+    row.set(Constants.ColumnKeyNames.END_POSITION, variantToBqUtils.getEnd(variantContext,
+        useOneBasedCoordinate));
     row.set(Constants.ColumnKeyNames.REFERENCE_BASES,
             variantToBqUtils.getReferenceBases(variantContext));
     row.set(Constants.ColumnKeyNames.NAMES, variantToBqUtils.getNames(variantContext));

--- a/src/main/java/com/google/gcp_variant_transforms/library/BigQueryRowGeneratorImpl.java
+++ b/src/main/java/com/google/gcp_variant_transforms/library/BigQueryRowGeneratorImpl.java
@@ -27,8 +27,7 @@ public class BigQueryRowGeneratorImpl implements BigQueryRowGenerator, Serializa
     row.set(Constants.ColumnKeyNames.REFERENCE_NAME, variantContext.getContig());
     row.set(Constants.ColumnKeyNames.START_POSITION, variantToBqUtils.getStart(variantContext,
         useOneBasedCoordinate));
-    row.set(Constants.ColumnKeyNames.END_POSITION, variantToBqUtils.getEnd(variantContext,
-        useOneBasedCoordinate));
+    row.set(Constants.ColumnKeyNames.END_POSITION, variantContext.getEnd());
     row.set(Constants.ColumnKeyNames.REFERENCE_BASES,
             variantToBqUtils.getReferenceBases(variantContext));
     row.set(Constants.ColumnKeyNames.NAMES, variantToBqUtils.getNames(variantContext));

--- a/src/main/java/com/google/gcp_variant_transforms/library/SchemaGenerator.java
+++ b/src/main/java/com/google/gcp_variant_transforms/library/SchemaGenerator.java
@@ -15,5 +15,5 @@ public interface SchemaGenerator {
    * @param vcfHeader
    * @return TableSchema
    */
-  TableSchema getSchema(VCFHeader vcfHeader);
+  TableSchema getSchema(VCFHeader vcfHeader, boolean useOneBasedCoordinate);
 }

--- a/src/main/java/com/google/gcp_variant_transforms/library/SchemaUtils.java
+++ b/src/main/java/com/google/gcp_variant_transforms/library/SchemaUtils.java
@@ -39,8 +39,10 @@ public class SchemaUtils {
 
   public static class FieldDescription {
     public static final String REFERENCE_NAME = "Reference name.";
-    public static final String START_POSITION = "Start position (0-based). Corresponds to the " +
-        "first base of the string of reference bases.";
+    public static final String START_POSITION_ZERO_BASED = "Start position (0-based). Corresponds" +
+        " to the first base of the string of reference bases.";
+    public static final String START_POSITION_ONE_BASED = "Start position (1-based). Corresponds" +
+        " to the first base of the string of reference bases.";
     public static final String END_POSITION = "End position. Corresponds to the first base " +
         "after the last base in the reference allele.";
     public static final String REFERENCE_BASES = "Reference bases.";
@@ -95,10 +97,10 @@ public class SchemaUtils {
     put(FieldIndex.CALLS_PHASESET, Constants.ColumnKeyNames.CALLS_PHASESET);
   }};
 
-  // Maps a constant Field name to its description.
+  // Maps a constant Field name to its description, start position excluded. Start position
+  // depends on the input useOneBasedCoordinate flag.
   public static Map<String, String> constantFieldNameToDescriptionMap = Stream.of(new String[][] {
       {Constants.ColumnKeyNames.REFERENCE_NAME, FieldDescription.REFERENCE_NAME},
-      {Constants.ColumnKeyNames.START_POSITION, FieldDescription.START_POSITION},
       {Constants.ColumnKeyNames.END_POSITION, FieldDescription.END_POSITION},
       {Constants.ColumnKeyNames.REFERENCE_BASES, FieldDescription.REFERENCE_BASES},
       {Constants.ColumnKeyNames.ALTERNATE_BASES, FieldDescription.ALTERNATE_BASES},
@@ -170,6 +172,34 @@ public class SchemaUtils {
         put(VCFConstants.GENOTYPE_KEY, Constants.ColumnKeyNames.CALLS_GENOTYPE);
         put(VCFConstants.PHASE_SET_KEY, Constants.ColumnKeyNames.CALLS_PHASESET);
   }};
+
+  /**
+   * Get start position field description. It should specify the coordinate is 1-based or 0-based.
+   * @param useOneBasedCoordinate Flag of using 1-based coordinate or not.
+   * @return Description of start position field.
+   */
+  public static String getStartPositionDescription(boolean useOneBasedCoordinate) {
+    return useOneBasedCoordinate ? FieldDescription.START_POSITION_ONE_BASED :
+        FieldDescription.START_POSITION_ZERO_BASED;
+  }
+
+  /**
+   * Get the description of fields. For start position, it depends on the flag of
+   * useOneBasedCoordinate and the description should mention the coordinate is 1-based or 0-based.
+   * @param fieldName Flag of using 1-based coordinate or not.
+   * @param useOneBasedCoordinate
+   * @return Description of the field.
+   */
+  public static String getDescription(String fieldName, boolean useOneBasedCoordinate) {
+    if (constantFieldNameToDescriptionMap.containsKey(fieldName)) {
+      return constantFieldNameToDescriptionMap.get(fieldName);
+    } else if (fieldName.equals(Constants.ColumnKeyNames.START_POSITION)){
+      return getStartPositionDescription(useOneBasedCoordinate);
+    } else {
+      throw new RuntimeException("There is no such a field name \"" + fieldName + "\" in the " +
+          "columns.");
+    }
+  }
 
   /**
    * Returns the sanitized field name according to BigQuery restrictions.

--- a/src/main/java/com/google/gcp_variant_transforms/library/VariantToBqUtils.java
+++ b/src/main/java/com/google/gcp_variant_transforms/library/VariantToBqUtils.java
@@ -23,6 +23,24 @@ public interface VariantToBqUtils {
   public String getReferenceBases(VariantContext variantContext);
 
   /**
+   * Get start position. Default coordinate in {@link VariantContext} is 1-based. If
+   * useOneBasedCoordinate is false, we will use 0-based coordinate.
+   * @param variantContext
+   * @param useOneBasedCoordinate Flag for using 1-based coordinates or not.
+   * @return Start position for specific 1-based or 0-based coordinate.
+   */
+  public int getStart(VariantContext variantContext, boolean useOneBasedCoordinate);
+
+  /**
+   * Get end position. Default coordinate in {@link VariantContext} is 1-based. If
+   * useOneBasedCoordinate is false, we will use 0-based coordinate.
+   * @param variantContext
+   * @param useOneBasedCoordinate Flag for using 1-based coordinates or not.
+   * @return End position for specific 1-based or 0-based coordinate.
+   */
+  public int getEnd(VariantContext variantContext, boolean useOneBasedCoordinate);
+
+  /**
    * Get names from VariantContext's ID field. It should be a semi-colon separated list of
    * unique identifiers where available. In each separated ID, set null in this field if there is
    * a missing value.

--- a/src/main/java/com/google/gcp_variant_transforms/library/VariantToBqUtils.java
+++ b/src/main/java/com/google/gcp_variant_transforms/library/VariantToBqUtils.java
@@ -32,15 +32,6 @@ public interface VariantToBqUtils {
   public int getStart(VariantContext variantContext, boolean useOneBasedCoordinate);
 
   /**
-   * Get end position. Default coordinate in {@link VariantContext} is 1-based. If
-   * useOneBasedCoordinate is false, we will use 0-based coordinate.
-   * @param variantContext
-   * @param useOneBasedCoordinate Flag for using 1-based coordinates or not.
-   * @return End position for specific 1-based or 0-based coordinate.
-   */
-  public int getEnd(VariantContext variantContext, boolean useOneBasedCoordinate);
-
-  /**
    * Get names from VariantContext's ID field. It should be a semi-colon separated list of
    * unique identifiers where available. In each separated ID, set null in this field if there is
    * a missing value.

--- a/src/main/java/com/google/gcp_variant_transforms/library/VariantToBqUtilsImpl.java
+++ b/src/main/java/com/google/gcp_variant_transforms/library/VariantToBqUtilsImpl.java
@@ -49,11 +49,6 @@ public class VariantToBqUtilsImpl implements VariantToBqUtils, Serializable {
     return useOneBasedCoordinate ? oneBasedStartPosition : oneBasedStartPosition - 1;
   }
 
-  public int getEnd(VariantContext variantContext, boolean useOneBasedCoordinate) {
-    int oneBasedEndPosition = variantContext.getEnd();
-    return useOneBasedCoordinate ? oneBasedEndPosition : oneBasedEndPosition - 1;
-  }
-
   public List<TableRow> getAlternateBases(VariantContext variantContext) {
     List<TableRow> altMetadata = new ArrayList<>();
     List<Allele> altAlleles = variantContext.getAlternateAlleles();

--- a/src/main/java/com/google/gcp_variant_transforms/library/VariantToBqUtilsImpl.java
+++ b/src/main/java/com/google/gcp_variant_transforms/library/VariantToBqUtilsImpl.java
@@ -4,6 +4,7 @@ package com.google.gcp_variant_transforms.library;
 
 import com.google.api.services.bigquery.model.TableRow;
 import com.google.gcp_variant_transforms.common.Constants;
+import com.google.gcp_variant_transforms.entity.Variant;
 import com.google.gcp_variant_transforms.exceptions.CountNotMatchException;
 import htsjdk.variant.variantcontext.Allele;
 import htsjdk.variant.variantcontext.Genotype;
@@ -41,6 +42,16 @@ public class VariantToBqUtilsImpl implements VariantToBqUtils, Serializable {
       nameList.add(replaceMissingWithNull(name));
     }
     return nameList;
+  }
+
+  public int getStart(VariantContext variantContext, boolean useOneBasedCoordinate) {
+    int oneBasedStartPosition = variantContext.getStart();
+    return useOneBasedCoordinate ? oneBasedStartPosition : oneBasedStartPosition - 1;
+  }
+
+  public int getEnd(VariantContext variantContext, boolean useOneBasedCoordinate) {
+    int oneBasedEndPosition = variantContext.getEnd();
+    return useOneBasedCoordinate ? oneBasedEndPosition : oneBasedEndPosition - 1;
   }
 
   public List<TableRow> getAlternateBases(VariantContext variantContext) {

--- a/src/main/java/com/google/gcp_variant_transforms/options/VcfToBqContext.java
+++ b/src/main/java/com/google/gcp_variant_transforms/options/VcfToBqContext.java
@@ -19,6 +19,7 @@ public class VcfToBqContext extends AbstractContext {
   private final String output;
   private final String malformedRecordsMessage;
   private final Boolean allowMalformedRecords;
+  private final Boolean useOneBasedCoordinate;
   private ImmutableList<String> headerLines = null;
   private VCFHeader vcfHeader = null;
   private TableSchema bqSchema = null;
@@ -29,6 +30,7 @@ public class VcfToBqContext extends AbstractContext {
     this.inputFile = options.getInputFile();
     this.output = options.getOutput();
     this.allowMalformedRecords = options.getAllowMalformedRecords();
+    this.useOneBasedCoordinate = options.getUseOneBasedCoordinate();
     this.malformedRecordsMessage = options.getMalformedRecordsReportPath();
     validateFlags();
   }
@@ -72,6 +74,8 @@ public class VcfToBqContext extends AbstractContext {
   public boolean getAllowMalformedRecords() {
     return this.allowMalformedRecords;
   }
+
+  public boolean getUseOneBasedCoordinate() { return this.useOneBasedCoordinate; }
 
   public void setVCFHeader(VCFHeader vcfHeader){
     this.vcfHeader = vcfHeader;

--- a/src/main/java/com/google/gcp_variant_transforms/options/VcfToBqOptions.java
+++ b/src/main/java/com/google/gcp_variant_transforms/options/VcfToBqOptions.java
@@ -22,8 +22,13 @@ public interface VcfToBqOptions extends PipelineOptions {
   String getInputFile();
   void setInputFile(String value);
 
+  @Description("Flag for using 1-based coordinate")
+  @Default.Boolean(false)
+  public Boolean getUseOneBasedCoordinate();
+  void setUseOneBasedCoordinate(Boolean value);
+
   @Description("Flag for allowing malformed records")
-  @Default.Boolean(true)
+  @Default.Boolean(false)
   public Boolean getAllowMalformedRecords();
   void setAllowMalformedRecords(Boolean value);
 

--- a/src/main/java/com/google/gcp_variant_transforms/task/VcfToBqTask.java
+++ b/src/main/java/com/google/gcp_variant_transforms/task/VcfToBqTask.java
@@ -49,7 +49,8 @@ public class VcfToBqTask implements Task {
     setPipelineOptions(this.options);
     context.setHeaderLines(headerReader.getHeaderLines());
     context.setVCFHeader(parser.generateVCFHeader(context.getHeaderLines()));
-    context.setBqSchema(schemaGenerator.getSchema(context.getVCFHeader()));
+    context.setBqSchema(schemaGenerator.getSchema(context.getVCFHeader(),
+        context.getUseOneBasedCoordinate()));
     pipelineRunner.runPipeline();
   }
 

--- a/src/test/java/com/google/gcp_variant_transforms/library/BigQueryRowGeneratorTest.java
+++ b/src/test/java/com/google/gcp_variant_transforms/library/BigQueryRowGeneratorTest.java
@@ -83,7 +83,8 @@ public class BigQueryRowGeneratorTest {
     // Build BQ rows.
     rows = new ArrayList<>();
     for (int i = 0; i < vcfRecords.size(); ++i) {
-      rows.add(bigQueryRowGenerator.convertToBQRow(vcfCodec.decode(vcfRecords.get(i)), vcfHeader));
+      rows.add(bigQueryRowGenerator.convertToBQRow(vcfCodec.decode(vcfRecords.get(i)), vcfHeader,
+          true));
     }
 
     // The first row covers all base fields without missing field value(".").

--- a/src/test/java/com/google/gcp_variant_transforms/library/SchemaGeneratorImplTest.java
+++ b/src/test/java/com/google/gcp_variant_transforms/library/SchemaGeneratorImplTest.java
@@ -66,7 +66,7 @@ public class SchemaGeneratorImplTest {
   @Test
   public void testGetFields_whenGetReferenceField_thenIsEqualTo() {
     // Column: reference field
-    ImmutableList<TableFieldSchema> fields = schemaGen.getFields(mockedVcfHeader);
+    ImmutableList<TableFieldSchema> fields = schemaGen.getFields(mockedVcfHeader, true);
     UnmodifiableListIterator<TableFieldSchema> fieldIterator =
         fields.listIterator(SchemaUtils.FieldIndex.REFERENCE_NAME);
     TableFieldSchema referenceField = fieldIterator.next();
@@ -82,7 +82,7 @@ public class SchemaGeneratorImplTest {
   @Test
   public void testGetFields_whenGetStartPosField_thenIsEqualTo() {
     // Column: start position
-    ImmutableList<TableFieldSchema> fields = schemaGen.getFields(mockedVcfHeader);
+    ImmutableList<TableFieldSchema> fields = schemaGen.getFields(mockedVcfHeader, true);
     UnmodifiableListIterator<TableFieldSchema> fieldIterator =
         fields.listIterator(SchemaUtils.FieldIndex.START_POSITION);
     TableFieldSchema startPosField = fieldIterator.next();
@@ -90,7 +90,7 @@ public class SchemaGeneratorImplTest {
     assertThat(startPosField.getName())
         .isEqualTo(Constants.ColumnKeyNames.START_POSITION);
     assertThat(startPosField.getDescription())
-        .isEqualTo(SchemaUtils.FieldDescription.START_POSITION);
+        .isEqualTo(SchemaUtils.getDescription(Constants.ColumnKeyNames.START_POSITION, true));
     assertThat(startPosField.getMode()).isEqualTo(SchemaUtils.BQFieldMode.NULLABLE);
     assertThat(startPosField.getType()).isEqualTo(SchemaUtils.BQFieldType.INTEGER);
   }
@@ -98,7 +98,7 @@ public class SchemaGeneratorImplTest {
   @Test
   public void testGetFields_whenGetEndPosField_thenIsEqualTo() {
     // Column: end position
-    ImmutableList<TableFieldSchema> fields = schemaGen.getFields(mockedVcfHeader);
+    ImmutableList<TableFieldSchema> fields = schemaGen.getFields(mockedVcfHeader, true);
     UnmodifiableListIterator<TableFieldSchema> fieldIterator =
         fields.listIterator(SchemaUtils.FieldIndex.END_POSITION);
     TableFieldSchema endPosField = fieldIterator.next();
@@ -114,7 +114,7 @@ public class SchemaGeneratorImplTest {
   @Test
   public void testGetFields_whenGetReferenceBasesField_thenIsEqualTo() {
     // Column: reference bases
-    ImmutableList<TableFieldSchema> fields = schemaGen.getFields(mockedVcfHeader);
+    ImmutableList<TableFieldSchema> fields = schemaGen.getFields(mockedVcfHeader, true);
     UnmodifiableListIterator<TableFieldSchema> fieldIterator =
         fields.listIterator(SchemaUtils.FieldIndex.REFERENCE_BASES);
     TableFieldSchema referenceBasesField = fieldIterator.next();
@@ -130,7 +130,7 @@ public class SchemaGeneratorImplTest {
   @Test
   public void testGetFields_whenGetAlternateBasesField_thenIsEqualTo() {
     // Column: reference bases
-    ImmutableList<TableFieldSchema> fields = schemaGen.getFields(mockedVcfHeader);
+    ImmutableList<TableFieldSchema> fields = schemaGen.getFields(mockedVcfHeader, true);
     UnmodifiableListIterator<TableFieldSchema> fieldIterator =
         fields.listIterator(SchemaUtils.FieldIndex.ALTERNATE_BASES);
     TableFieldSchema alternateBasesField = fieldIterator.next();
@@ -146,7 +146,7 @@ public class SchemaGeneratorImplTest {
   @Test
   public void testGetFields_whenGetNamesField_thenIsEqualTo() {
     // Column: names
-    ImmutableList<TableFieldSchema> fields = schemaGen.getFields(mockedVcfHeader);
+    ImmutableList<TableFieldSchema> fields = schemaGen.getFields(mockedVcfHeader, true);
     UnmodifiableListIterator<TableFieldSchema> fieldIterator =
         fields.listIterator(SchemaUtils.FieldIndex.NAMES);
     TableFieldSchema namesField = fieldIterator.next();
@@ -162,7 +162,7 @@ public class SchemaGeneratorImplTest {
   @Test
   public void testGetFields_whenGetQualityField_thenIsEqualTo() {
     // Column: quality
-    ImmutableList<TableFieldSchema> fields = schemaGen.getFields(mockedVcfHeader);
+    ImmutableList<TableFieldSchema> fields = schemaGen.getFields(mockedVcfHeader, true);
     UnmodifiableListIterator<TableFieldSchema> fieldIterator =
         fields.listIterator(SchemaUtils.FieldIndex.QUALITY);
     TableFieldSchema qualityField = fieldIterator.next();
@@ -178,7 +178,7 @@ public class SchemaGeneratorImplTest {
   @Test
   public void testGetFields_whenGetFilterField_thenIsEqualTo() {
     // Column: filter
-    ImmutableList<TableFieldSchema> fields = schemaGen.getFields(mockedVcfHeader);
+    ImmutableList<TableFieldSchema> fields = schemaGen.getFields(mockedVcfHeader, true);
     UnmodifiableListIterator<TableFieldSchema> fieldIterator =
         fields.listIterator(SchemaUtils.FieldIndex.FILTER);
     TableFieldSchema filterField = fieldIterator.next();
@@ -194,7 +194,7 @@ public class SchemaGeneratorImplTest {
   @Test
   public void testGetFields_whenGetCallsField_thenIsEqualTo() {
     // Column: calls record
-    ImmutableList<TableFieldSchema> fields = schemaGen.getFields(mockedVcfHeader);
+    ImmutableList<TableFieldSchema> fields = schemaGen.getFields(mockedVcfHeader, true);
     UnmodifiableListIterator<TableFieldSchema> fieldIterator =
         fields.listIterator(SchemaUtils.FieldIndex.CALLS);
     TableFieldSchema callsField = fieldIterator.next();
@@ -212,7 +212,7 @@ public class SchemaGeneratorImplTest {
     // Columns: calls record's constant subfields
     // Verifies that the call record's sub-Fields maintain data integrity
     // after they are added to the call record in a FieldList.
-    ImmutableList<TableFieldSchema> fields = schemaGen.getFields(mockedVcfHeader);
+    ImmutableList<TableFieldSchema> fields = schemaGen.getFields(mockedVcfHeader, true);
     UnmodifiableListIterator<TableFieldSchema> fieldIterator =
         fields.listIterator(SchemaUtils.FieldIndex.CALLS);
     TableFieldSchema callsField = fieldIterator.next();
@@ -331,7 +331,7 @@ public class SchemaGeneratorImplTest {
     String readDepthDescription = "Read Depth";
     String haplotypeQualityDescription = "Haplotype Quality";
 
-    TableFieldSchema callsField = schemaGen.createRecordField(sampleVcfHeader, fieldName);
+    TableFieldSchema callsField = schemaGen.createRecordField(sampleVcfHeader, fieldName, true);
     List<TableFieldSchema> callsSubFields = callsField.getFields();
 
     TableFieldSchema genotypeQuality = callsSubFields.get(genotypeQualityIndex);
@@ -363,7 +363,7 @@ public class SchemaGeneratorImplTest {
     String fieldName = Constants.ColumnKeyNames.CALLS;
     sampleVcfHeader.addMetaDataLine(new VCFFormatHeaderLine(
         "PS", 1, VCFHeaderLineType.String, "description"));
-    TableFieldSchema callsField = schemaGen.createRecordField(sampleVcfHeader, fieldName);
+    TableFieldSchema callsField = schemaGen.createRecordField(sampleVcfHeader, fieldName, true);
     List<TableFieldSchema> callsSubFields = callsField.getFields();
     // 3 constants fields and 5 added from sample v4.2 header:
     // 'GQ', 'DP', 'HP', 'GL'
@@ -396,7 +396,7 @@ public class SchemaGeneratorImplTest {
     String alleleFrequencyName = "AF";
     String alleleFrequencyDescription = "Allele Frequency";
 
-    TableFieldSchema altField = schemaGen.createRecordField(sampleVcfHeader, fieldName);
+    TableFieldSchema altField = schemaGen.createRecordField(sampleVcfHeader, fieldName, true);
     List<TableFieldSchema> altSubFields = altField.getFields();
     TableFieldSchema alleleFrequency = altSubFields.get(alleleFrequencyIndex);
     TableFieldSchema altBaseField = altSubFields.get(altBaseIndex);
@@ -481,5 +481,13 @@ public class SchemaGeneratorImplTest {
     String actualFieldName = SchemaUtils.getSanitizedFieldName(fieldName);
 
     assertThat(actualFieldName).isEqualTo(fieldName); // Should be unchanged.
+  }
+
+  @Test
+  public void testGetStartPositionDescription_whenCheckingFlagElement_thenTrue() {
+    assertThat(SchemaUtils.getStartPositionDescription(true))
+        .isEqualTo(SchemaUtils.FieldDescription.START_POSITION_ONE_BASED);
+    assertThat(SchemaUtils.getStartPositionDescription(false))
+        .isEqualTo(SchemaUtils.FieldDescription.START_POSITION_ZERO_BASED);
   }
 }

--- a/src/test/java/com/google/gcp_variant_transforms/library/VariantToBqUtilsTest.java
+++ b/src/test/java/com/google/gcp_variant_transforms/library/VariantToBqUtilsTest.java
@@ -44,6 +44,8 @@ public class VariantToBqUtilsTest {
   private static final boolean TEST_DB_PRESENT = true;
   private static final boolean TEST_DB_NOT_PRESENT = false;
   private static final double TEST_AF = 0.333;
+  private static final int TEST_START_POSITION = 10000;
+  private static final int TEST_END_POSITION = 10001;
   private static final int TEST_NS = 2;
   private static final int DEFAULT_GENOTYPE = -1;
 
@@ -227,6 +229,24 @@ public class VariantToBqUtilsTest {
     when(variantContext.getReference()).thenReturn(refAllele);
 
     assertThat(variantToBqUtils.getReferenceBases(variantContext)).isEqualTo(TEST_REFERENCE_BASES);
+  }
+
+  @Test
+  public void testGetStartPosition_whenCheckingFlagInput_thenTrue() {
+    when(variantContext.getStart()).thenReturn(TEST_START_POSITION);
+    assertThat(variantToBqUtils.getStart(variantContext, true))
+        .isEqualTo(TEST_START_POSITION);
+    assertThat(variantToBqUtils.getStart(variantContext, false))
+        .isEqualTo(TEST_START_POSITION - 1);
+  }
+
+  @Test
+  public void testGetEndPosition_whenCheckingFlagInput_thenTrue() {
+    when(variantContext.getEnd()).thenReturn(TEST_END_POSITION);
+    assertThat(variantToBqUtils.getEnd(variantContext, true))
+        .isEqualTo(TEST_END_POSITION);
+    assertThat(variantToBqUtils.getEnd(variantContext, false))
+        .isEqualTo(TEST_END_POSITION - 1);
   }
 
   @Test

--- a/src/test/java/com/google/gcp_variant_transforms/library/VariantToBqUtilsTest.java
+++ b/src/test/java/com/google/gcp_variant_transforms/library/VariantToBqUtilsTest.java
@@ -45,7 +45,6 @@ public class VariantToBqUtilsTest {
   private static final boolean TEST_DB_NOT_PRESENT = false;
   private static final double TEST_AF = 0.333;
   private static final int TEST_START_POSITION = 10000;
-  private static final int TEST_END_POSITION = 10001;
   private static final int TEST_NS = 2;
   private static final int DEFAULT_GENOTYPE = -1;
 
@@ -238,15 +237,6 @@ public class VariantToBqUtilsTest {
         .isEqualTo(TEST_START_POSITION);
     assertThat(variantToBqUtils.getStart(variantContext, false))
         .isEqualTo(TEST_START_POSITION - 1);
-  }
-
-  @Test
-  public void testGetEndPosition_whenCheckingFlagInput_thenTrue() {
-    when(variantContext.getEnd()).thenReturn(TEST_END_POSITION);
-    assertThat(variantToBqUtils.getEnd(variantContext, true))
-        .isEqualTo(TEST_END_POSITION);
-    assertThat(variantToBqUtils.getEnd(variantContext, false))
-        .isEqualTo(TEST_END_POSITION - 1);
   }
 
   @Test


### PR DESCRIPTION
### Update
- Add an option of Using 1-based coordinate flag, and default value is false(0-based).
- For start and end position, if use_1_based_coordiante is true, return the position from `VariantContext` since it is 1-based, if not, return the `position - 1` to use 0-based coordiantes.
### Test
```
./gradlew test
```